### PR TITLE
Add native iOS App Intents for wallet actions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
         "react-native-gesture-handler": "2.32.0",
         "react-native-keychain": "10.0.0",
         "react-native-mmkv": "4.3.1",
-        "react-native-nitro-ark": "0.0.139",
+        "react-native-nitro-ark": "0.0.140",
         "react-native-nitro-modules": "0.35.6",
         "react-native-qrcode-svg": "6.3.21",
         "react-native-quick-base64": "3.0.0",
@@ -1533,7 +1533,7 @@
 
     "react-native-mmkv": ["react-native-mmkv@4.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-APyGGaaHtayVgT18dBM8QGGZKr9pGfSTiBwbbPNzhGGfJQSU7awLGRGq879OqYl31HmVks9hOBLCs+qfgacRZg=="],
 
-    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.139", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-AtTqVqO76k6AXGAoG46EgbD5bcPFOaqncfir3x7F3cnY3wOODIuFpAnJJvvkVlNMxBwQ4IERaCs+TSx6Qe8D7A=="],
+    "react-native-nitro-ark": ["react-native-nitro-ark@0.0.140", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "^0.35.6" } }, "sha512-UdQg/vsmNPcV3VsOfW/NOVUs1/P7WHS4xgqc56TXvyovDSh1erU82CL+yXuAXkBk97yEgUa4I6LdWJnKCfaSmA=="],
 
     "react-native-nitro-modules": ["react-native-nitro-modules@0.35.6", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-3Cb7s+O5tpZ6RdIiPOB/wi3IMfBxD6tl6VDF8gJ5zvM/BEGTWxwMMLjzmWmsYPKekdbYBznF6qp2d2SxixPy8g=="],
 

--- a/client/ios/Noah.xcodeproj/project.pbxproj
+++ b/client/ios/Noah.xcodeproj/project.pbxproj
@@ -16,6 +16,15 @@
 		90A46AE18A163BF183119CB6 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC16E7980CEC87034661C98D /* ExpoModulesProvider.swift */; };
 		91774CF337F101C31032D925 /* libPods-noah-common-Noah-Signet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F05BC2FED16A519F831B178 /* libPods-noah-common-Noah-Signet.a */; };
 		A29D6E062D7F45109FBD3DBF /* noah.icon in Resources */ = {isa = PBXBuildFile; fileRef = 4750FC36FC574FD6949E1B64 /* noah.icon */; };
+		A91F6B022F4A100100ABC001 /* NoahAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91F6B012F4A100100ABC001 /* NoahAppIntents.swift */; };
+		A91F6B032F4A100100ABC001 /* NoahAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91F6B012F4A100100ABC001 /* NoahAppIntents.swift */; };
+		A91F6B042F4A100100ABC001 /* NoahAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91F6B012F4A100100ABC001 /* NoahAppIntents.swift */; };
+		B71A00112F4B100100ABC001 /* NoahArkBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = B71A00022F4B100100ABC001 /* NoahArkBridge.mm */; };
+		B71A00122F4B100100ABC001 /* NoahArkBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = B71A00022F4B100100ABC001 /* NoahArkBridge.mm */; };
+		B71A00132F4B100100ABC001 /* NoahArkBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = B71A00022F4B100100ABC001 /* NoahArkBridge.mm */; };
+		B71A00212F4B100100ABC001 /* NoahNativeWalletService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71A00032F4B100100ABC001 /* NoahNativeWalletService.swift */; };
+		B71A00222F4B100100ABC001 /* NoahNativeWalletService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71A00032F4B100100ABC001 /* NoahNativeWalletService.swift */; };
+		B71A00232F4B100100ABC001 /* NoahNativeWalletService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71A00032F4B100100ABC001 /* NoahNativeWalletService.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		C39DD7062E0C95AF000CB6A9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
 		C39DD70B2E0C95AF000CB6A9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
@@ -135,7 +144,11 @@
 		5EFBDBE072290378716253F8 /* Pods-noah-common-Noah-Signet.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-noah-common-Noah-Signet.release.xcconfig"; path = "Target Support Files/Pods-noah-common-Noah-Signet/Pods-noah-common-Noah-Signet.release.xcconfig"; sourceTree = "<group>"; };
 		85BF3676FE0AADD8774596BB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = noah/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		8B5FFA8A288023BD8CCB7C91 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-noah-common-Noah-Regtest/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		A91F6B012F4A100100ABC001 /* NoahAppIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NoahAppIntents.swift; path = SharedAppIntents/NoahAppIntents.swift; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = noah/SplashScreen.storyboard; sourceTree = "<group>"; };
+		B71A00012F4B100100ABC001 /* NoahArkBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NoahArkBridge.h; path = noah/NoahArkBridge.h; sourceTree = "<group>"; };
+		B71A00022F4B100100ABC001 /* NoahArkBridge.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = NoahArkBridge.mm; path = noah/NoahArkBridge.mm; sourceTree = "<group>"; };
+		B71A00032F4B100100ABC001 /* NoahNativeWalletService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NoahNativeWalletService.swift; path = noah/NoahNativeWalletService.swift; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		BF9E301C9E066D61A855F010 /* Pods-noah-common-Noah-Regtest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-noah-common-Noah-Regtest.release.xcconfig"; path = "Target Support Files/Pods-noah-common-Noah-Regtest/Pods-noah-common-Noah-Regtest.release.xcconfig"; sourceTree = "<group>"; };
 		C379B55F2EC4D043004DFDC1 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
@@ -281,6 +294,10 @@
 			isa = PBXGroup;
 			children = (
 				F11748412D0307B40044C1D9 /* AppDelegate.swift */,
+				A91F6B012F4A100100ABC001 /* NoahAppIntents.swift */,
+				B71A00012F4B100100ABC001 /* NoahArkBridge.h */,
+				B71A00022F4B100100ABC001 /* NoahArkBridge.mm */,
+				B71A00032F4B100100ABC001 /* NoahNativeWalletService.swift */,
 				F11748442D0722820044C1D9 /* noah-Bridging-Header.h */,
 				BB2F792B24A3F905000567C9 /* Supporting */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
@@ -1064,6 +1081,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */,
+				A91F6B022F4A100100ABC001 /* NoahAppIntents.swift in Sources */,
+				B71A00112F4B100100ABC001 /* NoahArkBridge.mm in Sources */,
+				B71A00212F4B100100ABC001 /* NoahNativeWalletService.swift in Sources */,
 				90A46AE18A163BF183119CB6 /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1073,6 +1093,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				C39DD7062E0C95AF000CB6A9 /* AppDelegate.swift in Sources */,
+				A91F6B032F4A100100ABC001 /* NoahAppIntents.swift in Sources */,
+				B71A00122F4B100100ABC001 /* NoahArkBridge.mm in Sources */,
+				B71A00222F4B100100ABC001 /* NoahNativeWalletService.swift in Sources */,
 				7DF2E503400EE172682AF07B /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1082,6 +1105,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				C39DD71B2E0C973E000CB6A9 /* AppDelegate.swift in Sources */,
+				A91F6B042F4A100100ABC001 /* NoahAppIntents.swift in Sources */,
+				B71A00132F4B100100ABC001 /* NoahArkBridge.mm in Sources */,
+				B71A00232F4B100100ABC001 /* NoahNativeWalletService.swift in Sources */,
 				601942D0AB763A941862EDE2 /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -281,7 +281,7 @@ PODS:
     - ReactNativeDependencies
     - Yoga
   - MMKVCore (2.4.0)
-  - NitroArk (0.0.139):
+  - NitroArk (0.0.140):
     - hermes-engine
     - NitroModules
     - RCTRequired
@@ -3264,7 +3264,7 @@ SPEC CHECKSUMS:
   hermes-engine: 5d77dc1ef8157f3f04498d283c0e822362e992f9
   MapLibreReactNative: 5df4460492c6c8af365fc6107f48f0e922d915ad
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroArk: fcc321841a502e8c6cb788764d727dff99715398
+  NitroArk: 60d885e5ba783a8454fed4b0ab36d41616edd970
   NitroMmkv: 1ff46eceb958298b1d7c013a6314432438b77a62
   NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
   NoahTools: efecfcff1688c6e63b9acb210286badaa3eaac36

--- a/client/ios/SharedAppIntents/NoahAppIntents.swift
+++ b/client/ios/SharedAppIntents/NoahAppIntents.swift
@@ -388,6 +388,9 @@ struct NoahAppShortcuts: AppShortcutsProvider {
           "Create an Ark address with \(.applicationName)",
           "Get an Ark address from \(.applicationName)",
           "Generate an Ark address with \(.applicationName)",
+          "Make an Ark address with \(.applicationName)",
+          "Show me an Ark address from \(.applicationName)",
+          "Receive with Ark in \(.applicationName)",
         ],
         shortTitle: "Create Ark Address",
         systemImageName: "qrcode"
@@ -412,6 +415,12 @@ struct NoahAppShortcuts: AppShortcutsProvider {
           "Create a Lightning invoice with \(.applicationName)",
           "Request sats with \(.applicationName)",
           "Generate an invoice with \(.applicationName)",
+          "Make a Lightning invoice with \(.applicationName)",
+          "Create a payment request with \(.applicationName)",
+          "Receive sats with \(.applicationName)",
+          "Create a \(\.$amountSats) sat Lightning invoice with \(.applicationName)",
+          "Make a \(\.$amountSats) sat invoice with \(.applicationName)",
+          "Request \(\.$amountSats) sats with \(.applicationName)",
         ],
         shortTitle: "Create Lightning Invoice",
         systemImageName: "bolt.badge.plus"

--- a/client/ios/SharedAppIntents/NoahAppIntents.swift
+++ b/client/ios/SharedAppIntents/NoahAppIntents.swift
@@ -146,7 +146,7 @@ struct CreateNoahLightningInvoiceIntent: AppIntent {
 }
 
 @available(iOS 26.0, *)
-private struct CreateNoahLightningInvoiceWithSnippetIntent: AppIntent {
+struct CreateNoahLightningInvoiceWithSnippetIntent: AppIntent {
   static let title: LocalizedStringResource = "Create Lightning Invoice"
   static let description = IntentDescription(
     "Creates a BOLT11 Lightning invoice from Noah without opening the app."
@@ -191,7 +191,7 @@ private struct CreateNoahLightningInvoiceWithSnippetIntent: AppIntent {
 }
 
 @available(iOS 26.0, *)
-private struct NoahLightningInvoiceSnippetIntent: SnippetIntent {
+struct NoahLightningInvoiceSnippetIntent: SnippetIntent {
   static let title: LocalizedStringResource = "Lightning Invoice"
   static let isDiscoverable = false
 
@@ -219,7 +219,7 @@ private struct NoahLightningInvoiceSnippetIntent: SnippetIntent {
 }
 
 @available(iOS 26.0, *)
-private struct CopyNoahLightningInvoiceIntent: AppIntent {
+struct CopyNoahLightningInvoiceIntent: AppIntent {
   static let title: LocalizedStringResource = "Copy Invoice"
   static let description = IntentDescription("Copies a Lightning invoice to the clipboard.")
   static let authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication

--- a/client/ios/SharedAppIntents/NoahAppIntents.swift
+++ b/client/ios/SharedAppIntents/NoahAppIntents.swift
@@ -5,6 +5,7 @@ import UIKit
 import UniformTypeIdentifiers
 
 private enum NoahAppIntentError: LocalizedError {
+  case addressCopyUnavailable
   case addressUnavailable
   case balanceUnavailable
   case copyUnavailable
@@ -14,6 +15,8 @@ private enum NoahAppIntentError: LocalizedError {
 
   var errorDescription: String? {
     switch self {
+    case .addressCopyUnavailable:
+      return "Noah couldn't copy the Ark address. Try again while Noah is open."
     case .addressUnavailable:
       return "Noah couldn't create an Ark address. Try again."
     case .balanceUnavailable:
@@ -70,14 +73,111 @@ struct CreateNoahArkAddressIntent: AppIntent {
       throw NoahAppIntentError.addressUnavailable
     }
 
-    await MainActor.run {
-      UIPasteboard.general.string = address
+    return .result(
+      value: address,
+      dialog: "Created a new Ark address."
+    )
+  }
+}
+
+@available(iOS 26.0, *)
+struct CreateNoahArkAddressWithSnippetIntent: AppIntent {
+  static let title: LocalizedStringResource = "Create Ark Address"
+  static let description = IntentDescription(
+    "Creates a new Ark address from Noah without opening the app."
+  )
+  static let authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication
+
+  func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog & ShowsSnippetIntent {
+    let address: String
+    do {
+      address = try await NoahNativeWalletService.shared.newAddress()
+    } catch {
+      throw NoahAppIntentError.addressUnavailable
     }
 
     return .result(
       value: address,
-      dialog: "Created a new Ark address and copied it to your clipboard."
+      dialog: IntentDialog(
+        full: "Created a new Ark address. Tap Copy Address to open Noah and copy it.",
+        supporting: "Your new Ark address is ready."
+      ),
+      snippetIntent: NoahArkAddressSnippetIntent(address: address)
     )
+  }
+}
+
+@available(iOS 26.0, *)
+struct NoahArkAddressSnippetIntent: SnippetIntent {
+  static let title: LocalizedStringResource = "Ark Address"
+  static let isDiscoverable = false
+
+  @Parameter(title: "Address")
+  var address: String
+
+  init() {}
+
+  init(address: String) {
+    self.address = address
+  }
+
+  func perform() async throws -> some IntentResult & ShowsSnippetView {
+    return .result(view: NoahArkAddressSnippetView(address: address))
+  }
+}
+
+@available(iOS 26.0, *)
+struct CopyNoahArkAddressIntent: AppIntent {
+  static let title: LocalizedStringResource = "Copy Address"
+  static let description = IntentDescription("Copies an Ark address to the clipboard.")
+  static let authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication
+  static let isDiscoverable = false
+  static let supportedModes: IntentModes = .foreground(.immediate)
+
+  @Parameter(title: "Address")
+  var address: String
+
+  init() {}
+
+  init(address: String) {
+    self.address = address
+  }
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    let pasteboard = UIPasteboard.general
+    pasteboard.setItems([
+      [UTType.utf8PlainText.identifier: address]
+    ])
+
+    guard pasteboard.string == address else {
+      throw NoahAppIntentError.addressCopyUnavailable
+    }
+
+    return .result(dialog: "Copied the Ark address to your clipboard.")
+  }
+}
+
+@available(iOS 26.0, *)
+private struct NoahArkAddressSnippetView: View {
+  let address: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Label("Ark Address", systemImage: "qrcode")
+        .font(.headline)
+
+      Text(address)
+        .font(.caption.monospaced())
+        .lineLimit(4)
+        .truncationMode(.middle)
+
+      Button(intent: CopyNoahArkAddressIntent(address: address)) {
+        Label("Copy Address", systemImage: "doc.on.doc")
+      }
+      .buttonStyle(.borderedProminent)
+    }
+    .padding()
   }
 }
 
@@ -282,17 +382,6 @@ struct NoahAppShortcuts: AppShortcutsProvider {
   @AppShortcutsBuilder
   static var appShortcuts: [AppShortcut] {
     AppShortcut(
-      intent: CreateNoahArkAddressIntent(),
-      phrases: [
-        "Create an Ark address with \(.applicationName)",
-        "Get an Ark address from \(.applicationName)",
-        "Generate an Ark address with \(.applicationName)",
-      ],
-      shortTitle: "Create Ark Address",
-      systemImageName: "qrcode"
-    )
-
-    AppShortcut(
       intent: GetNoahBalanceIntent(),
       phrases: [
         "What's my balance in \(.applicationName)",
@@ -302,6 +391,19 @@ struct NoahAppShortcuts: AppShortcutsProvider {
       shortTitle: "Check Balance",
       systemImageName: "bitcoinsign.circle"
     )
+
+    if #available(iOS 26.0, *) {
+      AppShortcut(
+        intent: CreateNoahArkAddressWithSnippetIntent(),
+        phrases: [
+          "Create an Ark address with \(.applicationName)",
+          "Get an Ark address from \(.applicationName)",
+          "Generate an Ark address with \(.applicationName)",
+        ],
+        shortTitle: "Create Ark Address",
+        systemImageName: "qrcode"
+      )
+    }
 
     if #available(iOS 26.0, *) {
       AppShortcut(

--- a/client/ios/SharedAppIntents/NoahAppIntents.swift
+++ b/client/ios/SharedAppIntents/NoahAppIntents.swift
@@ -1,0 +1,319 @@
+import AppIntents
+import Foundation
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+
+private enum NoahAppIntentError: LocalizedError {
+  case addressUnavailable
+  case balanceUnavailable
+  case copyUnavailable
+  case invoiceDescriptionTooLong
+  case invoiceUnavailable
+  case invalidAmount
+
+  var errorDescription: String? {
+    switch self {
+    case .addressUnavailable:
+      return "Noah couldn't create an Ark address. Try again."
+    case .balanceUnavailable:
+      return "Noah couldn't refresh your balance. Check your connection and try again."
+    case .copyUnavailable:
+      return "Noah couldn't copy the invoice. Try again while Noah is open."
+    case .invoiceDescriptionTooLong:
+      return "The invoice description must be 639 characters or fewer."
+    case .invoiceUnavailable:
+      return "Noah couldn't create the Lightning invoice. Check your connection and try again."
+    case .invalidAmount:
+      return "The amount must be at least one sat."
+    }
+  }
+}
+
+private func createNoahLightningInvoice(
+  amountSats: Int,
+  invoiceDescription: String?
+) async throws -> NoahArkBolt11Invoice {
+  guard amountSats > 0 else {
+    throw NoahAppIntentError.invalidAmount
+  }
+
+  let normalizedDescription = invoiceDescription?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  let effectiveDescription = normalizedDescription?.isEmpty == false ? normalizedDescription : nil
+  guard effectiveDescription?.utf16.count ?? 0 <= 639 else {
+    throw NoahAppIntentError.invoiceDescriptionTooLong
+  }
+
+  do {
+    return try await NoahNativeWalletService.shared.bolt11Invoice(
+      amountSat: UInt64(amountSats),
+      description: effectiveDescription
+    )
+  } catch {
+    throw NoahAppIntentError.invoiceUnavailable
+  }
+}
+
+struct CreateNoahArkAddressIntent: AppIntent {
+  static let title: LocalizedStringResource = "Create Ark Address"
+  static let description = IntentDescription(
+    "Creates a new Ark address from Noah without opening the app."
+  )
+  static let authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication
+
+  func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
+    let address: String
+    do {
+      address = try await NoahNativeWalletService.shared.newAddress()
+    } catch {
+      throw NoahAppIntentError.addressUnavailable
+    }
+
+    await MainActor.run {
+      UIPasteboard.general.string = address
+    }
+
+    return .result(
+      value: address,
+      dialog: "Created a new Ark address and copied it to your clipboard."
+    )
+  }
+}
+
+struct GetNoahBalanceIntent: AppIntent {
+  static let title: LocalizedStringResource = "Get Noah Balance"
+  static let description = IntentDescription(
+    "Synchronizes Noah and returns the current total balance."
+  )
+  static let authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication
+
+  func perform() async throws -> some IntentResult & ReturnsValue<Int> & ProvidesDialog {
+    let nativeBalance: NoahNativeWalletBalance
+    do {
+      nativeBalance = try await NoahNativeWalletService.shared.refreshBalance()
+    } catch {
+      throw NoahAppIntentError.balanceUnavailable
+    }
+
+    guard nativeBalance.total <= UInt64(Int.max) else {
+      throw NoahAppIntentError.balanceUnavailable
+    }
+    let balance = Int(nativeBalance.total)
+
+    return .result(
+      value: balance,
+      dialog: "Your current Noah balance is \(balance) sats."
+    )
+  }
+}
+
+struct CreateNoahLightningInvoiceIntent: AppIntent {
+  static let title: LocalizedStringResource = "Create Lightning Invoice"
+  static let description = IntentDescription(
+    "Creates a BOLT11 Lightning invoice from Noah without opening the app."
+  )
+  static let authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication
+
+  @Parameter(
+    title: "Amount in Sats",
+    description: "The number of satoshis to request.",
+    requestValueDialog: "How many sats would you like to request?"
+  )
+  var amountSats: Int
+
+  @Parameter(
+    title: "Description",
+    description: "An optional memo included in the invoice."
+  )
+  var invoiceDescription: String?
+
+  static var parameterSummary: some ParameterSummary {
+    Summary("Create a Lightning invoice for \(\.$amountSats) sats")
+  }
+
+  func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
+    let invoice = try await createNoahLightningInvoice(
+      amountSats: amountSats,
+      invoiceDescription: invoiceDescription
+    )
+
+    return .result(
+      value: invoice.paymentRequest,
+      dialog: "Created a Lightning invoice for \(amountSats) sats."
+    )
+  }
+}
+
+@available(iOS 26.0, *)
+private struct CreateNoahLightningInvoiceWithSnippetIntent: AppIntent {
+  static let title: LocalizedStringResource = "Create Lightning Invoice"
+  static let description = IntentDescription(
+    "Creates a BOLT11 Lightning invoice from Noah without opening the app."
+  )
+  static let authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication
+
+  @Parameter(
+    title: "Amount in Sats",
+    description: "The number of satoshis to request.",
+    requestValueDialog: "How many sats would you like to request?"
+  )
+  var amountSats: Int
+
+  @Parameter(
+    title: "Description",
+    description: "An optional memo included in the invoice."
+  )
+  var invoiceDescription: String?
+
+  static var parameterSummary: some ParameterSummary {
+    Summary("Create a Lightning invoice for \(\.$amountSats) sats")
+  }
+
+  func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog & ShowsSnippetIntent {
+    let invoice = try await createNoahLightningInvoice(
+      amountSats: amountSats,
+      invoiceDescription: invoiceDescription
+    )
+
+    return .result(
+      value: invoice.paymentRequest,
+      dialog: IntentDialog(
+        full: "Created a Lightning invoice for \(amountSats) sats. Tap Copy Invoice to open Noah and copy it.",
+        supporting: "Your \(amountSats)-sat Lightning invoice is ready."
+      ),
+      snippetIntent: NoahLightningInvoiceSnippetIntent(
+        invoice: invoice.paymentRequest,
+        amountSats: amountSats
+      )
+    )
+  }
+}
+
+@available(iOS 26.0, *)
+private struct NoahLightningInvoiceSnippetIntent: SnippetIntent {
+  static let title: LocalizedStringResource = "Lightning Invoice"
+  static let isDiscoverable = false
+
+  @Parameter(title: "Invoice")
+  var invoice: String
+
+  @Parameter(title: "Amount in Sats")
+  var amountSats: Int
+
+  init() {}
+
+  init(invoice: String, amountSats: Int) {
+    self.invoice = invoice
+    self.amountSats = amountSats
+  }
+
+  func perform() async throws -> some IntentResult & ShowsSnippetView {
+    return .result(
+      view: NoahLightningInvoiceSnippetView(
+        invoice: invoice,
+        amountSats: amountSats
+      )
+    )
+  }
+}
+
+@available(iOS 26.0, *)
+private struct CopyNoahLightningInvoiceIntent: AppIntent {
+  static let title: LocalizedStringResource = "Copy Invoice"
+  static let description = IntentDescription("Copies a Lightning invoice to the clipboard.")
+  static let authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication
+  static let isDiscoverable = false
+  static let supportedModes: IntentModes = .foreground(.immediate)
+
+  @Parameter(title: "Invoice")
+  var invoice: String
+
+  init() {}
+
+  init(invoice: String) {
+    self.invoice = invoice
+  }
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    let pasteboard = UIPasteboard.general
+    pasteboard.setItems([
+      [UTType.utf8PlainText.identifier: invoice]
+    ])
+
+    guard pasteboard.string == invoice else {
+      throw NoahAppIntentError.copyUnavailable
+    }
+
+    return .result(dialog: "Copied the Lightning invoice to your clipboard.")
+  }
+}
+
+@available(iOS 26.0, *)
+private struct NoahLightningInvoiceSnippetView: View {
+  let invoice: String
+  let amountSats: Int
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Label("Lightning Invoice", systemImage: "bolt.fill")
+        .font(.headline)
+
+      Text("\(amountSats.formatted()) sats")
+        .font(.title2.bold())
+
+      Text(invoice)
+        .font(.caption.monospaced())
+        .lineLimit(4)
+        .truncationMode(.middle)
+
+      Button(intent: CopyNoahLightningInvoiceIntent(invoice: invoice)) {
+        Label("Copy Invoice", systemImage: "doc.on.doc")
+      }
+      .buttonStyle(.borderedProminent)
+    }
+    .padding()
+  }
+}
+
+@available(iOS 17.4, *)
+struct NoahAppShortcuts: AppShortcutsProvider {
+  @AppShortcutsBuilder
+  static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: CreateNoahArkAddressIntent(),
+      phrases: [
+        "Create an Ark address with \(.applicationName)",
+        "Get an Ark address from \(.applicationName)",
+        "Generate an Ark address with \(.applicationName)",
+      ],
+      shortTitle: "Create Ark Address",
+      systemImageName: "qrcode"
+    )
+
+    AppShortcut(
+      intent: GetNoahBalanceIntent(),
+      phrases: [
+        "What's my balance in \(.applicationName)",
+        "Check my \(.applicationName) balance",
+        "How many sats are in \(.applicationName)",
+      ],
+      shortTitle: "Check Balance",
+      systemImageName: "bitcoinsign.circle"
+    )
+
+    if #available(iOS 26.0, *) {
+      AppShortcut(
+        intent: CreateNoahLightningInvoiceWithSnippetIntent(),
+        phrases: [
+          "Create a Lightning invoice with \(.applicationName)",
+          "Request sats with \(.applicationName)",
+          "Generate an invoice with \(.applicationName)",
+        ],
+        shortTitle: "Create Lightning Invoice",
+        systemImageName: "bolt.badge.plus"
+      )
+    }
+  }
+}

--- a/client/ios/SharedAppIntents/NoahAppIntents.swift
+++ b/client/ios/SharedAppIntents/NoahAppIntents.swift
@@ -418,9 +418,6 @@ struct NoahAppShortcuts: AppShortcutsProvider {
           "Make a Lightning invoice with \(.applicationName)",
           "Create a payment request with \(.applicationName)",
           "Receive sats with \(.applicationName)",
-          "Create a \(\.$amountSats) sat Lightning invoice with \(.applicationName)",
-          "Make a \(\.$amountSats) sat invoice with \(.applicationName)",
-          "Request \(\.$amountSats) sats with \(.applicationName)",
         ],
         shortTitle: "Create Lightning Invoice",
         systemImageName: "bolt.badge.plus"

--- a/client/ios/SharedAppIntents/NoahAppIntents.swift
+++ b/client/ios/SharedAppIntents/NoahAppIntents.swift
@@ -381,17 +381,6 @@ private struct NoahLightningInvoiceSnippetView: View {
 struct NoahAppShortcuts: AppShortcutsProvider {
   @AppShortcutsBuilder
   static var appShortcuts: [AppShortcut] {
-    AppShortcut(
-      intent: GetNoahBalanceIntent(),
-      phrases: [
-        "What's my balance in \(.applicationName)",
-        "Check my \(.applicationName) balance",
-        "How many sats are in \(.applicationName)",
-      ],
-      shortTitle: "Check Balance",
-      systemImageName: "bitcoinsign.circle"
-    )
-
     if #available(iOS 26.0, *) {
       AppShortcut(
         intent: CreateNoahArkAddressWithSnippetIntent(),
@@ -404,6 +393,17 @@ struct NoahAppShortcuts: AppShortcutsProvider {
         systemImageName: "qrcode"
       )
     }
+
+    AppShortcut(
+      intent: GetNoahBalanceIntent(),
+      phrases: [
+        "What's my balance in \(.applicationName)",
+        "Check my \(.applicationName) balance",
+        "How many sats are in \(.applicationName)",
+      ],
+      shortTitle: "Check Balance",
+      systemImageName: "bitcoinsign.circle"
+    )
 
     if #available(iOS 26.0, *) {
       AppShortcut(

--- a/client/ios/noah/AppDelegate.swift
+++ b/client/ios/noah/AppDelegate.swift
@@ -1,4 +1,5 @@
 internal import Expo
+import AppIntents
 import React
 import ReactAppDependencyProvider
 
@@ -27,6 +28,10 @@ class AppDelegate: ExpoAppDelegate {
       in: window,
       launchOptions: launchOptions)
 #endif
+
+    if #available(iOS 17.4, *) {
+      NoahAppShortcuts.updateAppShortcutParameters()
+    }
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/client/ios/noah/NoahArkBridge.h
+++ b/client/ios/noah/NoahArkBridge.h
@@ -1,0 +1,82 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NoahArkWalletConfiguration : NSObject
+
+@property(nonatomic) BOOL regtest;
+@property(nonatomic) BOOL signet;
+@property(nonatomic) BOOL bitcoin;
+@property(nonatomic, copy) NSString *arkURL;
+@property(nonatomic, copy) NSString *userAgent;
+@property(nonatomic, copy) NSString *esploraURL;
+@property(nonatomic, copy) NSString *bitcoindURL;
+@property(nonatomic, copy) NSString *bitcoindCookie;
+@property(nonatomic, copy) NSString *bitcoindUser;
+@property(nonatomic, copy) NSString *bitcoindPassword;
+@property(nonatomic) uint32_t vtxoRefreshExpiryThreshold;
+@property(nonatomic) uint64_t fallbackFeeRate;
+@property(nonatomic) uint16_t htlcReceiveClaimDelta;
+@property(nonatomic) uint16_t vtxoExitMargin;
+@property(nonatomic) uint32_t roundTransactionRequiredConfirmations;
+
+@end
+
+@interface NoahArkOffchainBalance : NSObject
+
+@property(nonatomic, readonly) uint64_t spendable;
+@property(nonatomic, readonly) uint64_t pendingLightningSend;
+@property(nonatomic, readonly) uint64_t claimableLightningReceive;
+@property(nonatomic, readonly) uint64_t pendingInRound;
+@property(nonatomic, readonly) uint64_t pendingExit;
+@property(nonatomic, readonly) uint64_t pendingBoard;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+@interface NoahArkOnchainBalance : NSObject
+
+@property(nonatomic, readonly) uint64_t immature;
+@property(nonatomic, readonly) uint64_t trustedPending;
+@property(nonatomic, readonly) uint64_t untrustedPending;
+@property(nonatomic, readonly) uint64_t confirmed;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+@interface NoahArkBolt11Invoice : NSObject
+
+@property(nonatomic, copy, readonly) NSString *paymentRequest;
+@property(nonatomic, copy, readonly) NSString *paymentSecret;
+@property(nonatomic, copy, readonly) NSString *paymentHash;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+@interface NoahArkBridge : NSObject
+
++ (BOOL)isWalletLoaded;
+
++ (BOOL)loadWalletAtPath:(NSString *)dataDirectory
+                 mnemonic:(NSString *)mnemonic
+             configuration:(NoahArkWalletConfiguration *)configuration
+                     error:(NSError **)error;
+
++ (BOOL)syncWithError:(NSError **)error;
++ (BOOL)onchainSyncWithError:(NSError **)error;
+
++ (nullable NoahArkOffchainBalance *)offchainBalanceWithError:(NSError **)error;
++ (nullable NoahArkOnchainBalance *)onchainBalanceWithError:(NSError **)error;
++ (nullable NSString *)newAddressWithError:(NSError **)error;
+
++ (nullable NoahArkBolt11Invoice *)bolt11InvoiceForAmountSat:(uint64_t)amountSat
+                                                  description:(nullable NSString *)description
+                                                        token:(nullable NSString *)token
+                                                        error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/client/ios/noah/NoahArkBridge.mm
+++ b/client/ios/noah/NoahArkBridge.mm
@@ -256,8 +256,6 @@ BOOL PerformVoidOperation(NSString *name, NSError **error, Operation operation) 
       nativeToken = std::make_unique<rust::String>(ToStdString(token));
     }
 
-    // The generated CXX argument is named amount_msat, but the current Bark API
-    // and Noah's existing React Native integration both interpret it as sats.
     const auto invoice = bark_cxx::bolt11_invoice(
         amountSat, nativeDescription.get(), nativeToken.get());
     return [[NoahArkBolt11Invoice alloc]

--- a/client/ios/noah/NoahArkBridge.mm
+++ b/client/ios/noah/NoahArkBridge.mm
@@ -1,0 +1,276 @@
+#import "NoahArkBridge.h"
+
+#include <ark_cxx.h>
+#include <exception>
+#include <memory>
+#include <string>
+
+namespace {
+
+NSString *const NoahArkBridgeErrorDomain = @"com.noahwallet.ark-bridge";
+
+std::string ToStdString(NSString *value) {
+  const char *utf8 = value.UTF8String;
+  return utf8 == nullptr ? std::string() : std::string(utf8);
+}
+
+NSString *ToNSString(const rust::String &value) {
+  return [[NSString alloc] initWithBytes:value.data()
+                                  length:value.length()
+                                encoding:NSUTF8StringEncoding];
+}
+
+void AssignError(NSError **error, NSString *operation, const char *message) {
+  if (error == nullptr) {
+    return;
+  }
+
+  NSString *reason = message == nullptr ? @"Unknown wallet error" : [NSString stringWithUTF8String:message];
+  *error = [NSError errorWithDomain:NoahArkBridgeErrorDomain
+                               code:1
+                           userInfo:@{
+                             NSLocalizedDescriptionKey: [NSString stringWithFormat:@"%@ failed: %@", operation, reason]
+                           }];
+}
+
+template <typename Operation>
+BOOL PerformVoidOperation(NSString *name, NSError **error, Operation operation) {
+  try {
+    operation();
+    return YES;
+  } catch (const std::exception &exception) {
+    AssignError(error, name, exception.what());
+    return NO;
+  } catch (...) {
+    AssignError(error, name, "Unknown wallet error");
+    return NO;
+  }
+}
+
+}  // namespace
+
+@implementation NoahArkWalletConfiguration
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _arkURL = @"";
+    _userAgent = @"";
+    _esploraURL = @"";
+    _bitcoindURL = @"";
+    _bitcoindCookie = @"";
+    _bitcoindUser = @"";
+    _bitcoindPassword = @"";
+  }
+  return self;
+}
+
+@end
+
+@interface NoahArkOffchainBalance ()
+
+- (instancetype)initWithSpendable:(uint64_t)spendable
+              pendingLightningSend:(uint64_t)pendingLightningSend
+         claimableLightningReceive:(uint64_t)claimableLightningReceive
+                     pendingInRound:(uint64_t)pendingInRound
+                        pendingExit:(uint64_t)pendingExit
+                       pendingBoard:(uint64_t)pendingBoard;
+
+@end
+
+@implementation NoahArkOffchainBalance
+
+- (instancetype)initWithSpendable:(uint64_t)spendable
+              pendingLightningSend:(uint64_t)pendingLightningSend
+         claimableLightningReceive:(uint64_t)claimableLightningReceive
+                     pendingInRound:(uint64_t)pendingInRound
+                        pendingExit:(uint64_t)pendingExit
+                       pendingBoard:(uint64_t)pendingBoard {
+  self = [super init];
+  if (self) {
+    _spendable = spendable;
+    _pendingLightningSend = pendingLightningSend;
+    _claimableLightningReceive = claimableLightningReceive;
+    _pendingInRound = pendingInRound;
+    _pendingExit = pendingExit;
+    _pendingBoard = pendingBoard;
+  }
+  return self;
+}
+
+@end
+
+@interface NoahArkOnchainBalance ()
+
+- (instancetype)initWithImmature:(uint64_t)immature
+                  trustedPending:(uint64_t)trustedPending
+                untrustedPending:(uint64_t)untrustedPending
+                       confirmed:(uint64_t)confirmed;
+
+@end
+
+@implementation NoahArkOnchainBalance
+
+- (instancetype)initWithImmature:(uint64_t)immature
+                  trustedPending:(uint64_t)trustedPending
+                untrustedPending:(uint64_t)untrustedPending
+                       confirmed:(uint64_t)confirmed {
+  self = [super init];
+  if (self) {
+    _immature = immature;
+    _trustedPending = trustedPending;
+    _untrustedPending = untrustedPending;
+    _confirmed = confirmed;
+  }
+  return self;
+}
+
+@end
+
+@interface NoahArkBolt11Invoice ()
+
+- (instancetype)initWithPaymentRequest:(NSString *)paymentRequest
+                          paymentSecret:(NSString *)paymentSecret
+                            paymentHash:(NSString *)paymentHash;
+
+@end
+
+@implementation NoahArkBolt11Invoice
+
+- (instancetype)initWithPaymentRequest:(NSString *)paymentRequest
+                          paymentSecret:(NSString *)paymentSecret
+                            paymentHash:(NSString *)paymentHash {
+  self = [super init];
+  if (self) {
+    _paymentRequest = [paymentRequest copy];
+    _paymentSecret = [paymentSecret copy];
+    _paymentHash = [paymentHash copy];
+  }
+  return self;
+}
+
+@end
+
+@implementation NoahArkBridge
+
++ (BOOL)isWalletLoaded {
+  return bark_cxx::is_wallet_loaded();
+}
+
++ (BOOL)loadWalletAtPath:(NSString *)dataDirectory
+                 mnemonic:(NSString *)mnemonic
+             configuration:(NoahArkWalletConfiguration *)configuration
+                     error:(NSError **)error {
+  return PerformVoidOperation(@"Load wallet", error, [&]() {
+    bark_cxx::CreateOpts options;
+    options.regtest = configuration.regtest;
+    options.signet = configuration.signet;
+    options.bitcoin = configuration.bitcoin;
+    options.mnemonic = ToStdString(mnemonic);
+    options.birthday_height = nullptr;
+    options.config.ark = ToStdString(configuration.arkURL);
+    options.config.user_agent = ToStdString(configuration.userAgent);
+    options.config.esplora = ToStdString(configuration.esploraURL);
+    options.config.bitcoind = ToStdString(configuration.bitcoindURL);
+    options.config.bitcoind_cookie = ToStdString(configuration.bitcoindCookie);
+    options.config.bitcoind_user = ToStdString(configuration.bitcoindUser);
+    options.config.bitcoind_pass = ToStdString(configuration.bitcoindPassword);
+    options.config.vtxo_refresh_expiry_threshold = configuration.vtxoRefreshExpiryThreshold;
+    options.config.fallback_fee_rate = configuration.fallbackFeeRate;
+    options.config.htlc_recv_claim_delta = configuration.htlcReceiveClaimDelta;
+    options.config.vtxo_exit_margin = configuration.vtxoExitMargin;
+    options.config.round_tx_required_confirmations = configuration.roundTransactionRequiredConfirmations;
+
+    bark_cxx::load_wallet(ToStdString(dataDirectory), options);
+  });
+}
+
++ (BOOL)syncWithError:(NSError **)error {
+  return PerformVoidOperation(@"Ark sync", error, []() { bark_cxx::sync(); });
+}
+
++ (BOOL)onchainSyncWithError:(NSError **)error {
+  return PerformVoidOperation(@"On-chain sync", error, []() { bark_cxx::onchain_sync(); });
+}
+
++ (NoahArkOffchainBalance *)offchainBalanceWithError:(NSError **)error {
+  try {
+    const auto balance = bark_cxx::offchain_balance();
+    return [[NoahArkOffchainBalance alloc]
+        initWithSpendable:balance.spendable
+        pendingLightningSend:balance.pending_lightning_send
+        claimableLightningReceive:balance.claimable_lightning_receive
+        pendingInRound:balance.pending_in_round
+        pendingExit:balance.pending_exit
+        pendingBoard:balance.pending_board];
+  } catch (const std::exception &exception) {
+    AssignError(error, @"Read off-chain balance", exception.what());
+    return nil;
+  } catch (...) {
+    AssignError(error, @"Read off-chain balance", "Unknown wallet error");
+    return nil;
+  }
+}
+
++ (NoahArkOnchainBalance *)onchainBalanceWithError:(NSError **)error {
+  try {
+    const auto balance = bark_cxx::onchain_balance();
+    return [[NoahArkOnchainBalance alloc]
+        initWithImmature:balance.immature
+        trustedPending:balance.trusted_pending
+        untrustedPending:balance.untrusted_pending
+        confirmed:balance.confirmed];
+  } catch (const std::exception &exception) {
+    AssignError(error, @"Read on-chain balance", exception.what());
+    return nil;
+  } catch (...) {
+    AssignError(error, @"Read on-chain balance", "Unknown wallet error");
+    return nil;
+  }
+}
+
++ (NSString *)newAddressWithError:(NSError **)error {
+  try {
+    const auto result = bark_cxx::new_address();
+    return ToNSString(result.address);
+  } catch (const std::exception &exception) {
+    AssignError(error, @"Create Ark address", exception.what());
+    return nil;
+  } catch (...) {
+    AssignError(error, @"Create Ark address", "Unknown wallet error");
+    return nil;
+  }
+}
+
++ (NoahArkBolt11Invoice *)bolt11InvoiceForAmountSat:(uint64_t)amountSat
+                                          description:(NSString *)description
+                                                token:(NSString *)token
+                                                error:(NSError **)error {
+  try {
+    std::unique_ptr<rust::String> nativeDescription;
+    std::unique_ptr<rust::String> nativeToken;
+    if (description != nil) {
+      nativeDescription = std::make_unique<rust::String>(ToStdString(description));
+    }
+    if (token != nil) {
+      nativeToken = std::make_unique<rust::String>(ToStdString(token));
+    }
+
+    // The generated CXX argument is named amount_msat, but the current Bark API
+    // and Noah's existing React Native integration both interpret it as sats.
+    const auto invoice = bark_cxx::bolt11_invoice(
+        amountSat, nativeDescription.get(), nativeToken.get());
+    return [[NoahArkBolt11Invoice alloc]
+        initWithPaymentRequest:ToNSString(invoice.bolt11_invoice)
+        paymentSecret:ToNSString(invoice.payment_secret)
+        paymentHash:ToNSString(invoice.payment_hash)];
+  } catch (const std::exception &exception) {
+    AssignError(error, @"Create BOLT11 invoice", exception.what());
+    return nil;
+  } catch (...) {
+    AssignError(error, @"Create BOLT11 invoice", "Unknown wallet error");
+    return nil;
+  }
+}
+
+@end

--- a/client/ios/noah/NoahNativeWalletService.swift
+++ b/client/ios/noah/NoahNativeWalletService.swift
@@ -1,0 +1,201 @@
+import Foundation
+import Security
+
+struct NoahNativeWalletBalance {
+  let onchain: NoahArkOnchainBalance
+  let offchain: NoahArkOffchainBalance
+
+  var total: UInt64 {
+    onchain.confirmed
+      + onchain.immature
+      + onchain.trustedPending
+      + onchain.untrustedPending
+      + offchain.pendingExit
+      + offchain.pendingLightningSend
+      + offchain.pendingInRound
+      + offchain.spendable
+      + offchain.pendingBoard
+  }
+}
+
+enum NoahNativeWalletError: LocalizedError {
+  case invalidAppVariant
+  case documentsDirectoryUnavailable
+  case mnemonicUnavailable(OSStatus)
+  case invalidMnemonic
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidAppVariant:
+      return "Noah's wallet network is unavailable."
+    case .documentsDirectoryUnavailable:
+      return "Noah's wallet storage is unavailable."
+    case .mnemonicUnavailable(let status):
+      if status == errSecItemNotFound {
+        return "No Noah wallet was found on this device."
+      }
+      return "Noah could not access the wallet key."
+    case .invalidMnemonic:
+      return "Noah's wallet key is invalid."
+    }
+  }
+}
+
+actor NoahNativeWalletService {
+  static let shared = NoahNativeWalletService()
+
+  private init() {}
+
+  func loadWallet() throws {
+    guard !NoahArkBridge.isWalletLoaded() else {
+      return
+    }
+
+    let variant = try appVariant()
+    let mnemonic = try readMnemonic(for: variant)
+
+    try NoahArkBridge.loadWallet(
+      atPath: try walletDataDirectory(for: variant),
+      mnemonic: mnemonic,
+      configuration: walletConfiguration(for: variant)
+    )
+  }
+
+  func sync() throws {
+    try NoahArkBridge.sync()
+  }
+
+  func onchainSync() throws {
+    try NoahArkBridge.onchainSync()
+  }
+
+  func offchainBalance() throws -> NoahArkOffchainBalance {
+    try NoahArkBridge.offchainBalance()
+  }
+
+  func onchainBalance() throws -> NoahArkOnchainBalance {
+    try NoahArkBridge.onchainBalance()
+  }
+
+  func newAddress() throws -> String {
+    try loadWallet()
+    return try NoahArkBridge.newAddress()
+  }
+
+  func bolt11Invoice(
+    amountSat: UInt64,
+    description: String? = nil,
+    token: String? = nil
+  ) throws -> NoahArkBolt11Invoice {
+    try loadWallet()
+    return try NoahArkBridge.bolt11Invoice(
+      forAmountSat: amountSat,
+      description: description,
+      token: token
+    )
+  }
+
+  func refreshBalance() throws -> NoahNativeWalletBalance {
+    try loadWallet()
+    try sync()
+    try onchainSync()
+
+    return try NoahNativeWalletBalance(
+      onchain: onchainBalance(),
+      offchain: offchainBalance()
+    )
+  }
+
+  private func appVariant() throws -> String {
+    guard let variant = Bundle.main.object(forInfoDictionaryKey: "APP_VARIANT") as? String,
+      ["mainnet", "signet", "regtest"].contains(variant)
+    else {
+      throw NoahNativeWalletError.invalidAppVariant
+    }
+    return variant
+  }
+
+  private func walletDataDirectory(for variant: String) throws -> String {
+    guard let documentsDirectory = FileManager.default.urls(
+      for: .documentDirectory,
+      in: .userDomainMask
+    ).first else {
+      throw NoahNativeWalletError.documentsDirectoryUnavailable
+    }
+
+    return documentsDirectory
+      .appendingPathComponent("noah-data-\(variant)", isDirectory: true)
+      .path
+  }
+
+  private func readMnemonic(for variant: String) throws -> String {
+    let query: [CFString: Any] = [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrService: "com.noah.mnemonic.\(variant)",
+      kSecAttrAccount: "noah",
+      kSecReturnData: true,
+      kSecMatchLimit: kSecMatchLimitOne,
+    ]
+
+    var item: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &item)
+    guard status == errSecSuccess else {
+      throw NoahNativeWalletError.mnemonicUnavailable(status)
+    }
+    guard let data = item as? Data,
+      let mnemonic = String(data: data, encoding: .utf8),
+      !mnemonic.isEmpty
+    else {
+      throw NoahNativeWalletError.invalidMnemonic
+    }
+    return mnemonic
+  }
+
+  private func walletConfiguration(for variant: String) -> NoahArkWalletConfiguration {
+    let configuration = NoahArkWalletConfiguration()
+    let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+      ?? "unknown"
+
+    configuration.userAgent = "noah-\(variant)-ios/\(version)"
+    configuration.fallbackFeeRate = 10_000
+    configuration.htlcReceiveClaimDelta = 18
+    configuration.vtxoExitMargin = 12
+
+    switch variant {
+    case "mainnet":
+      configuration.bitcoin = true
+      configuration.arkURL = "https://ark.second.tech"
+      configuration.esploraURL = effectiveEsploraURL(
+        for: variant,
+        defaultURL: "https://mempool.second.tech/api"
+      )
+      configuration.vtxoRefreshExpiryThreshold = 144
+      configuration.roundTransactionRequiredConfirmations = 2
+    case "signet":
+      configuration.signet = true
+      configuration.arkURL = "https://ark.signet.2nd.dev"
+      configuration.esploraURL = effectiveEsploraURL(
+        for: variant,
+        defaultURL: "https://esplora.signet.2nd.dev"
+      )
+      configuration.vtxoRefreshExpiryThreshold = 12
+      configuration.roundTransactionRequiredConfirmations = 1
+    case "regtest":
+      configuration.regtest = true
+      configuration.arkURL = "http://localhost:3535"
+      configuration.bitcoindURL = "http://localhost:18443"
+      configuration.bitcoindUser = "second"
+      configuration.bitcoindPassword = "ark"
+      configuration.vtxoRefreshExpiryThreshold = 24
+      configuration.roundTransactionRequiredConfirmations = 1
+    default:
+      break
+    }
+
+    return configuration
+  }
+
+  private func effectiveEsploraURL(for variant: String, defaultURL: String) -> String {
+    UserDefaults.standard.string(forKey: "noah.native.esplora.\(variant)") ?? defaultURL
+  }
+}

--- a/client/ios/noah/noah-Bridging-Header.h
+++ b/client/ios/noah/noah-Bridging-Header.h
@@ -1,3 +1,5 @@
 //
 // Use this file to import your target's public headers that you would like to expose to Swift.
 //
+
+#import "NoahArkBridge.h"

--- a/client/nitromodules/noah-tools/ios/NoahTools.swift
+++ b/client/nitromodules/noah-tools/ios/NoahTools.swift
@@ -201,14 +201,16 @@ class NoahTools: HybridNoahToolsSpec {
     }
 
     func storeNativeEsploraEndpoint(endpoint: String) throws -> Promise<Void> {
-        // This is Android-only, no-op on iOS
+        let variant = try performGetAppVariant()
+        UserDefaults.standard.set(endpoint, forKey: "noah.native.esplora.\(variant)")
         let promise = Promise<Void>()
         promise.resolve()
         return promise
     }
 
     func clearNativeEsploraEndpoint() throws -> Promise<Void> {
-        // This is Android-only, no-op on iOS
+        let variant = try performGetAppVariant()
+        UserDefaults.standard.removeObject(forKey: "noah.native.esplora.\(variant)")
         let promise = Promise<Void>()
         promise.resolve()
         return promise

--- a/client/package.json
+++ b/client/package.json
@@ -107,7 +107,7 @@
     "react-native-gesture-handler": "2.32.0",
     "react-native-keychain": "10.0.0",
     "react-native-mmkv": "4.3.1",
-    "react-native-nitro-ark": "0.0.139",
+    "react-native-nitro-ark": "0.0.140",
     "react-native-nitro-modules": "0.35.6",
     "react-native-qrcode-svg": "6.3.21",
     "react-native-quick-base64": "3.0.0",

--- a/client/src/screens/ArkInfoScreen.tsx
+++ b/client/src/screens/ArkInfoScreen.tsx
@@ -195,7 +195,7 @@ const buildSections = (arkInfo: BarkArkInfo) => [
       { label: "Round interval", value: arkInfo.round_interval, unit: "seconds" },
       { label: "Round nonces", value: arkInfo.nb_round_nonces },
       { label: "VTXO exit delta", value: arkInfo.vtxo_exit_delta, unit: "blocks" },
-      { label: "VTXO expiry delta", value: arkInfo.vtxo_expiry_delta, unit: "blocks" },
+      { label: "VTXO lifetime", value: arkInfo.vtxo_lifetime, unit: "blocks" },
       { label: "HTLC send expiry delta", value: arkInfo.htlc_send_expiry_delta, unit: "blocks" },
     ],
   },

--- a/docs/app_intents.md
+++ b/docs/app_intents.md
@@ -1,0 +1,99 @@
+# iOS App Intents
+
+## Architecture
+
+Noah implements App Intents directly in the existing iOS application targets. The
+[`@bacons/apple-targets`](https://github.com/EvanBacon/expo-apple-targets) config plugin is not
+required: it automates creation and regeneration of native targets for Expo projects, while Noah
+already commits and maintains its Xcode targets.
+
+The shared Swift implementation is in
+`client/ios/SharedAppIntents/NoahAppIntents.swift` and is compiled into the mainnet, signet, and
+regtest app targets. `AppDelegate` refreshes the registered App Shortcut parameters at launch.
+
+## Available actions
+
+### Get Noah Balance
+
+- Runs inside Noah's application process without bringing its UI to the foreground.
+- Loads the Ark wallet natively when the process is cold, using the mnemonic already stored in the
+  iOS Keychain and the same wallet data directory and network configuration as the React Native
+  wallet.
+- Runs Ark `sync` followed by `onchain_sync`, then reads `offchain_balance` and `onchain_balance`
+  directly from `react-native-nitro-ark`'s C++ interface.
+- Returns a freshly synchronized total rather than the widget's App Group cache. The total uses the
+  same fields as `client/src/lib/balanceUtils.ts`; a claimable Lightning receive is not counted
+  until it becomes part of Noah's normal balance calculation.
+- Requires authentication so the balance is not disclosed while the invoking device is locked.
+
+The native implementation is split between:
+
+- `NoahArkBridge`, an Objective-C++ adapter around the generated `ark_cxx.h` API.
+- `NoahNativeWalletService`, a Swift actor that serializes intent-side wallet operations and exposes
+  `loadWallet`, `sync`, `onchainSync`, `offchainBalance`, `onchainBalance`, and `bolt11Invoice`.
+
+The mnemonic is read only for a cold wallet load. It remains in Keychain under the existing
+`com.noah.mnemonic.<variant>` service and is never copied to App Group storage or logged.
+
+### Create Ark Address
+
+- Takes no parameters.
+- Loads the native Ark wallet if needed and calls `new_address`, matching Noah's existing React
+  Native receive flow.
+- Returns the new Ark address to Shortcuts and copies it to the system clipboard.
+- Requires authentication and runs in Noah's application process without foregrounding its UI.
+
+### Create Lightning Invoice
+
+- Accepts an amount in sats and an optional description.
+- Loads the native Ark wallet if needed and calls `bolt11_invoice` with the amount in satoshis,
+  matching Noah's existing React Native integration and the current Bark runtime contract.
+- Returns the BOLT11 payment request as the Shortcuts action's output. Siri gives a short
+  confirmation instead of reading the full invoice.
+- On iOS 26 and later, displays an interactive result with the amount, invoice, and a `Copy
+  Invoice` button. Invoice creation stays in the background; tapping the copy button brings Noah
+  to the foreground before writing and verifying the system clipboard.
+- On earlier iOS versions, the action returns the invoice without the interactive copy button.
+- Keeps the returned payment secret inside the native result; the App Intent never returns or logs
+  it.
+- Requires authentication.
+
+## Testing
+
+1. Build and launch the desired iOS variant at least once.
+2. Create or restore a wallet, then leave Noah in the background or terminate it to exercise the
+   native cold-load path.
+3. In Shortcuts, create a shortcut and select Noah from the Apps list.
+4. Change the wallet balance outside Noah, run `Get Noah Balance`, and confirm the result reflects
+   the live wallet after synchronization rather than the previous widget value.
+5. Run `Create Ark Address` and confirm that its returned and copied value is a valid address for
+   the installed Noah network variant.
+6. Run `Create Lightning Invoice`, inspect its output in Shortcuts, and decode it to confirm its
+   amount and optional description. On iOS 26 or later, tap `Copy Invoice`, confirm Noah opens,
+   and paste the invoice into another app.
+7. Test the supplied Siri phrases, such as “What's my balance in Noah” and “Create an Ark address
+   with Noah.” The system may use the variant's installed display name for signet and regtest.
+
+Apple's App Intents testing guidance recommends first verifying actions in the Shortcuts app, then
+testing their App Shortcut phrases with Siri. See
+[Creating your first app intent](https://developer.apple.com/documentation/appintents/creating-your-first-app-intent).
+
+### iOS 26.5 simulator limitation
+
+Auto-generated App Shortcut tiles currently fail on iOS 26.5 through iOS 27 simulator runtimes
+with `Couldn't find AppShortcutsProvider`, including in Apple's own App Intents sample. This is a
+simulator regression rather than a Noah registration error.
+
+To test the underlying intent on an affected simulator, create a normal shortcut with the `+`
+button, search for `Get Noah Balance`, `Create Ark Address`, or `Create Lightning Invoice`, and add
+the action manually.
+Disable `Show When Run` if the simulator's result presentation remains stuck. Test the automatic
+tiles and Siri phrases on a physical device or an older simulator runtime. See the
+[Apple Developer Forums report](https://developer.apple.com/forums/tags/simulator).
+
+## When a separate target would help
+
+A dedicated App Intents extension is useful only if a future action must run independently of the
+main app. Such an action needs native, extension-safe business logic; it cannot depend on Noah's
+React Native runtime. `@bacons/apple-targets` could automate that target, but Noah can also create
+and maintain it in Xcode in the same way as the existing widget extensions.


### PR DESCRIPTION
## Summary

- add an Objective-C++ bridge to the Nitro Ark C++ wallet API
- load the existing iOS wallet from Keychain for live sync and balance queries
- add App Intents for balance, Ark addresses, and Lightning invoices across all Noah variants
- show an interactive iOS 26 Lightning invoice result with a foreground-verified Copy Invoice action
- refresh App Shortcut parameters at launch and document the architecture and test flow

## Validation

- `just check` (lint, 68 unit tests, TypeScript)
- Noah-Signet Release build for a connected physical iPhone
- App Intents metadata export verified for the invoice, snippet, and copy intents
- signed Noah-Signet 0.1.10 (34) installed and launched on iOS 26.5