### PR TITLE
Build QR-first receive flow

### DIFF
--- a/client/.maestro/receive.yml
+++ b/client/.maestro/receive.yml
@@ -45,6 +45,16 @@ appId: com.noahwallet.regtest
 
 - tapOn: "Add amount"
 - tapOn:
+    id: "receive-note-button"
+- assertVisible: "What is the payment for?"
+- tapOn:
+    id: "receive-note-input"
+- inputText: "Test payment"
+- tapOn:
+    id: "receive-note-done"
+- assertVisible:
+    id: "receive-key-5"
+- tapOn:
     id: "receive-key-5"
 - tapOn:
     id: "receive-key-0"

--- a/client/.maestro/receive.yml
+++ b/client/.maestro/receive.yml
@@ -34,9 +34,11 @@ appId: com.noahwallet.regtest
 
 - tapOn:
     id: "receive-qr-button"
-- assertVisible: "Payment request"
-- assertVisible: "Ark"
-- assertVisible: "On-chain"
+- assertVisible: "Copy payment details"
+- assertVisible:
+    id: "receive-copy-ark"
+- assertVisible:
+    id: "receive-copy-onchain"
 - assertNotVisible:
     id: "receive-copy-lightning"
 - tapOn: "Close payment details"

--- a/client/.maestro/receive.yml
+++ b/client/.maestro/receive.yml
@@ -1,0 +1,68 @@
+appId: com.noahwallet.regtest
+---
+- launchApp:
+    clearState: true
+
+- tapOn: "Create Wallet"
+- assertVisible: "Noah is in beta"
+- tapOn: "I accept"
+- assertVisible: "Your Recovery Phrase"
+- tapOn: "I Have Saved It, Continue"
+- extendedWaitUntil:
+    visible: "Emergency Email"
+    timeout: 10000
+- tapOn: "Continue without email"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - assertVisible: "Disable battery optimization"
+      - tapOn: "Skip"
+- extendedWaitUntil:
+    visible: "Choose your Lightning Address"
+    timeout: 10000
+- tapOn: "Skip"
+- extendedWaitUntil:
+    visible: "History"
+    timeout: 10000
+
+- tapOn: "Receive"
+- extendedWaitUntil:
+    visible:
+      id: "receive-qr-button"
+    timeout: 15000
+
+- tapOn:
+    id: "receive-qr-button"
+- assertVisible: "Payment request"
+- assertVisible: "Ark"
+- assertVisible: "On-chain"
+- assertNotVisible:
+    id: "receive-copy-lightning"
+- tapOn: "Close payment details"
+
+- tapOn: "Add amount"
+- tapOn:
+    id: "receive-key-5"
+- tapOn:
+    id: "receive-key-0"
+- tapOn:
+    id: "receive-key-0"
+- tapOn: "Next"
+- extendedWaitUntil:
+    visible: "Edit amount"
+    timeout: 15000
+
+- tapOn:
+    id: "receive-qr-button"
+- assertVisible:
+    id: "receive-copy-lightning"
+- tapOn: "Close payment details"
+
+- tapOn: "Edit amount"
+- assertVisible: "Update request"
+- tapOn: "Remove amount"
+- assertVisible: "Add amount"
+
+- tapOn: "Share"
+- pressKey: BACK

--- a/client/ios/Podfile.lock
+++ b/client/ios/Podfile.lock
@@ -2835,17 +2835,17 @@ DEPENDENCIES:
   - ExpoClipboard (from `../../node_modules/expo-clipboard/ios`)
   - ExpoDevice (from `../../node_modules/expo-device/ios`)
   - "ExpoDomWebView (from `../../node_modules/@expo/dom-webview/ios`)"
-  - ExpoFileSystem (from `../../node_modules/expo-file-system/ios/ExpoFileSystem.podspec`)
-  - ExpoFont (from `../../node_modules/expo-font/ios/ExpoFont.podspec`)
+  - ExpoFileSystem (from `../../node_modules/expo-file-system/ios`)
+  - ExpoFont (from `../../node_modules/expo-font/ios`)
   - ExpoHaptics (from `../../node_modules/expo-haptics/ios`)
   - ExpoImagePicker (from `../../node_modules/expo-image-picker/ios`)
   - ExpoKeepAwake (from `../../node_modules/expo-keep-awake/ios`)
   - ExpoLocalAuthentication (from `../../node_modules/expo-local-authentication/ios`)
-  - ExpoLocation (from `../../node_modules/expo-location/ios/ExpoLocation.podspec`)
+  - ExpoLocation (from `../../node_modules/expo-location/ios`)
   - "ExpoLogBox (from `../../node_modules/@expo/log-box`)"
-  - ExpoModulesCore (from `../../node_modules/expo-modules-core/ExpoModulesCore.podspec`)
+  - ExpoModulesCore (from `../../node_modules/expo-modules-core`)
   - ExpoModulesJSI (from `../../node_modules/expo-modules-jsi/apple`)
-  - ExpoModulesWorklets (from `../../node_modules/expo-modules-core/ExpoModulesWorklets.podspec`)
+  - ExpoModulesWorklets (from `../../node_modules/expo-modules-core`)
   - ExpoModulesWorkletsAdapter (from `../../node_modules/expo-modules-core`)
   - ExpoNotifications (from `../../node_modules/expo-notifications/ios`)
   - ExpoSplashScreen (from `../../node_modules/expo-splash-screen/ios`)
@@ -2993,9 +2993,9 @@ EXTERNAL SOURCES:
   ExpoDomWebView:
     :path: "../../node_modules/@expo/dom-webview/ios"
   ExpoFileSystem:
-    :podspec: "../../node_modules/expo-file-system/ios/ExpoFileSystem.podspec"
+    :path: "../../node_modules/expo-file-system/ios"
   ExpoFont:
-    :podspec: "../../node_modules/expo-font/ios/ExpoFont.podspec"
+    :path: "../../node_modules/expo-font/ios"
   ExpoHaptics:
     :path: "../../node_modules/expo-haptics/ios"
   ExpoImagePicker:
@@ -3005,15 +3005,15 @@ EXTERNAL SOURCES:
   ExpoLocalAuthentication:
     :path: "../../node_modules/expo-local-authentication/ios"
   ExpoLocation:
-    :podspec: "../../node_modules/expo-location/ios/ExpoLocation.podspec"
+    :path: "../../node_modules/expo-location/ios"
   ExpoLogBox:
     :path: "../../node_modules/@expo/log-box"
   ExpoModulesCore:
-    :podspec: "../../node_modules/expo-modules-core/ExpoModulesCore.podspec"
+    :path: "../../node_modules/expo-modules-core"
   ExpoModulesJSI:
     :path: "../../node_modules/expo-modules-jsi/apple"
   ExpoModulesWorklets:
-    :podspec: "../../node_modules/expo-modules-core/ExpoModulesWorklets.podspec"
+    :path: "../../node_modules/expo-modules-core"
   ExpoModulesWorkletsAdapter:
     :path: "../../node_modules/expo-modules-core"
   ExpoNotifications:
@@ -3229,140 +3229,140 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  EXApplication: bbd517d50878ca1d121fb3843392beb210181e28
-  EXConstants: 092a945e490d473e0b6aec724684b36c447dd62a
+  EXApplication: f62b1a7f8a6efe1d43f38bfbe98cf4acea9b9421
+  EXConstants: 5633deb9d049de0e7312b682f73d0a929fb0c793
   EXJSONUtils: 7a1683cfa2cbe6d11fca97097d51a496755b0287
-  EXManifests: f9888c0bf5aaa6ddb7e3d4b224d6d54ac4ca84a4
-  Expo: 74ca681cd7a77385ac0ba805ba9b188cc8dd81c3
-  expo-dev-client: c8239657705784c0f9bb811df49252e1476ed619
-  expo-dev-launcher: 2acc677fde543454a7c5ac7368c150d848638568
-  expo-dev-menu: 7bcafc0c82ea4aca3e479b12c7c45b6f2be78bec
+  EXManifests: b9129302cc7af43d45c2f473fadb88e77f837273
+  Expo: 1e49d30c267df5cc3d8fe1b9127a8c5f0261ba50
+  expo-dev-client: 1dd5123a1160d4403bfbdda92072d3d12eb6c763
+  expo-dev-launcher: 136c4bd6eb0636764fd788ec61fcdef4746394bc
+  expo-dev-menu: 949e2f79e32bc8480013f0c98f41603251608835
   expo-dev-menu-interface: 7a59e803916fbfd1b96c75ff91ea8dddac7e722f
-  ExpoAsset: 1a913b91ccf6db8a5f68ba0c3ab75b8683766cf1
-  ExpoClipboard: 95055b11758f339b61d4d8064dd799df1cf03b7f
-  ExpoDevice: 93a72d7c2bd656a4f0c0d580523e390e9ee7fba5
-  ExpoDomWebView: beaec034e51bd028428b98bb1f2633ab79c6d095
-  ExpoFileSystem: b3fb2457e75eddc87dcadcd4cd0e237d12f79de7
-  ExpoFont: 59e1faf66ba9bcd232ae1e2ce58d202a48b6f65e
-  ExpoHaptics: 4503d2da51ff7109712ccdfe0e4939f66818183e
-  ExpoImagePicker: b6f0ce415819462b7cf28c47e7a9e147624ef29e
-  ExpoKeepAwake: c26f14275017370cc8a4b7b43a0e23361f2053a5
-  ExpoLocalAuthentication: 96989637e567a10cdeabe61e5c6026d30c0dc53f
-  ExpoLocation: 30cc8a3337823bf3725a332a96c07ce1d1521875
-  ExpoLogBox: 2c4225a62f1cfb943e6b2df4fa4fe2d136e06fb6
-  ExpoModulesCore: bcfe6d562972795433aa71547da40d53131c646c
-  ExpoModulesJSI: b20fefa4cdd9097e7e6b715466d1900b8c5d4711
-  ExpoModulesWorklets: eaf2898a6621e3c9a09c0479c1a4cb5f1b368d53
-  ExpoModulesWorkletsAdapter: abb7388bf2cdbcf02f49f66fd59bcde36af259f9
-  ExpoNotifications: 68ff0e02eef93ccb6739317eae4bfee6ea737023
-  ExpoSplashScreen: 9c11c0c7dd0c57853244d0ae640a63e42ede8ffd
-  ExpoSystemUI: ff3142b323ae7b4d11dc0b1dc4acfa30d92be7dc
-  ExpoTaskManager: 764fd9262a9db7a194b58eba220035a7fbd825e8
-  ExpoUI: 0df983122ad00cc8a31ac79e72fc8f585719ab87
-  EXUpdatesInterface: 92d2aa5194b6fb93ca8ab749db75665cb28b2e60
+  ExpoAsset: ce2b87849bbe7ec8b88fbf543cb23d2eda16bafb
+  ExpoClipboard: 42aa5588bc38bb74923cf0033bd01002c10f58e9
+  ExpoDevice: 5e5d4ece11404a66faa072ff6092f8f08efaface
+  ExpoDomWebView: fa9c72fe29dd4649197a7ecb07ddd870d55c4eda
+  ExpoFileSystem: 191afda4706089fd14caf9053608b725d8e1fc2f
+  ExpoFont: 17668fb7b4e06edf35e015183eb7bc09d83be637
+  ExpoHaptics: b382543a81889431177e929611566657a3eaf170
+  ExpoImagePicker: edd7229fbbe36cd373a39f2b502a656d4f490504
+  ExpoKeepAwake: 20a87dafdd9d84d68673e8eaf1a1c7eed8f92659
+  ExpoLocalAuthentication: cfa9a87c91f8f349e4fe82c9ac299e024f7ad765
+  ExpoLocation: 18ec97c10cb5f5c855afb4f7d90394e7a975a41d
+  ExpoLogBox: f7a6e4749816328bbcc0c906ec5108d304aeaa9b
+  ExpoModulesCore: fe8e8473687e6d9630498fe17e3c92a7b108314d
+  ExpoModulesJSI: 6cb6d299ace493e7dd20ba94c99e8c4799b07afd
+  ExpoModulesWorklets: 0b413c44a848159e224a148dd648b091352d8d9e
+  ExpoModulesWorkletsAdapter: bbfd881007100ddfc3656546a18b8fd4bcd0b42a
+  ExpoNotifications: c7988b48d9ea9f5ef3110eebba8db88f11d4aba7
+  ExpoSplashScreen: 071868f4e8a7c21efceea5a23c5b591fe79efa2f
+  ExpoSystemUI: e898bb2967e58b2e5ed8e26fb5a89bd004103d51
+  ExpoTaskManager: 980657a0f0edd86c036cc16dd140f3e15aede542
+  ExpoUI: 68dee135eedf279e6b75e551e95242fae91d3e38
+  EXUpdatesInterface: 38eacf4b5c0d686727ccbfebaf4f76eab3766a63
   FBLazyVector: 3c3be9a019176b5699455f7f66c5444b78a411c6
-  hermes-engine: 800b19913011fc271e8ab6b507f29b0fb4bea434
-  MapLibreReactNative: 9f1f16d5f5f522309ad1f2afc483a34cfc56fe6e
+  hermes-engine: 5d77dc1ef8157f3f04498d283c0e822362e992f9
+  MapLibreReactNative: 5df4460492c6c8af365fc6107f48f0e922d915ad
   MMKVCore: 3d16ce9f7d411e135020915fde98a056859a1efa
-  NitroArk: d16d0f91a8f154658246c4a31c42987b57cfa86f
-  NitroMmkv: 4b4f95387a15161b346a6a93b9c7072c179e0e88
-  NitroModules: c41b7b778d6557f1e517a80ec681a670321fa001
-  NoahTools: 690d5d90593c5634d2a9ab514a6c243d8212ef20
+  NitroArk: 60d885e5ba783a8454fed4b0ab36d41616edd970
+  NitroMmkv: 1ff46eceb958298b1d7c013a6314432438b77a62
+  NitroModules: ba9ddd723ffde85412ec774827d4a80ad9864b89
+  NoahTools: efecfcff1688c6e63b9acb210286badaa3eaac36
   RCTDeprecation: bccb6545c26db881ecddfd83a3f9ea82aba1605f
   RCTRequired: b2f74764d596fc0051f00fee94b49bf41a6f7f5a
   RCTSwiftUI: c6d6a31b849b9dfa64c33b55dc91ac15dd55774c
-  RCTSwiftUIWrapper: bdff268d65d662a79b1e571e841e1512275f9319
+  RCTSwiftUIWrapper: 0106c38ccc929e3b2f8815c50ab873e345ab2777
   RCTTypeSafety: 159e394bdab42023fbdd8fa022dfdc5577a8b9ad
   React: 4b2532a459d15e1adf6c22d3e399e5c85a94220f
   React-callinvoker: 0b8ce4057e02a0bd15cf0532596e8eb8c0392e92
-  React-Core: 5af045531a540ba3f65f07de1e3f585ddfb27948
-  React-Core-prebuilt: 405cf395d66cf694faf9aed3483a21b5515cec85
-  React-CoreModules: 99b194a721de84ccfc1be149a0de52647dc38c0e
-  React-cxxreact: b7e8e254074fd8111d147202b391ccf7816946a6
+  React-Core: 52b990bb36640833e636d5efc817ad4700dd7f93
+  React-Core-prebuilt: 39eb00d8ba4922167a3a70e2039b102fe42b6fe1
+  React-CoreModules: 43516d84b3851a850a835d32ec740db319e7bf9e
+  React-cxxreact: 9254233b543b9f49bdbcad329603e70be5582a0e
   React-debug: 6bc17013f4dc724c23c91e1c83220251d1eacee6
-  React-defaultsnativemodule: aec0c526e254a5ce43c79fecb83123f4aecd4199
-  React-domnativemodule: edd8f47d850a7d3fae0626b624a669e8a9e40f21
-  React-Fabric: a3b0ce70506ac2e737b9cd6667877382f2ee2f29
-  React-FabricComponents: 18bf172f8dc2308cb93c539713a3ac778192e225
-  React-FabricImage: 260ea6794cb5d08aacc0f591110bbf66dfc3ed80
-  React-featureflags: 828f711206ab1a3aa0ec40f39d9f7f793352489d
-  React-featureflagsnativemodule: cc62b7be20aa1e76efde77550dbc34db8556d604
-  React-graphics: 9a9fa8dd605d210a43d88e7d4c78bfff544b09ad
-  React-hermes: 6fd579ceeb680830fc508697acdd5e8cd8dbf29f
-  React-idlecallbacksnativemodule: af59e31212470464d6e6fda0f6cc7e5c413b5d29
-  React-ImageManager: 5c97e7ce5c37335c0392f629daba4c2143f0be2f
-  React-intersectionobservernativemodule: ea5682b04b6cff32fe57d5f0f530f07c33a55b34
-  React-jserrorhandler: baa4284f642fd0cbcf7664860abe7e18e54d05de
-  React-jsi: 7b14065a285f91b3dbe5448371ff575bbb523d59
-  React-jsiexecutor: 10b4ba40ec9fd571370dfee20251201f57712e79
-  React-jsinspector: ec4602cc56d9ec4c7789017a51a639052d4642e0
-  React-jsinspectorcdp: 46a17a5e80e4c84e734ba9cbc8fe4efaa496722a
-  React-jsinspectornetwork: a6743d072cb0e383de2b9bc7ddc4c824e617c681
-  React-jsinspectortracing: 24b2dd80722ef691af02d4aa6a1e32e1f61d9bfb
-  React-jsitooling: e483e01f15f2b11d8f5317372de762deaff4dcd9
-  React-jsitracing: db1285e61be69980443ca27e4f8dea36f8a3b906
-  React-logger: 35ab012027cc552057f7ca5d031c6721f896e6bc
-  React-Mapbuffer: 44dd007f917e2396afa0e70bbd70273237d93fde
-  React-microtasksnativemodule: f413ee411341fb3c34d20e85e9f6f524921fab15
-  React-mutationobservernativemodule: 58f6d2adf7d98e72b241608dfa2ddce414d2a4e7
-  react-native-bottom-tabs: e93dc04b1d64eb0932a099ca0d05a96f3f95fe61
-  react-native-quick-base64: 53393ee5ea472a7486e6652ad3d7a640ebf6ebda
-  react-native-safe-area-context: c4a6d0fbf9c77ee28dab7e4d4c369df7753f20d4
-  react-native-vector-icons: fa90a3e51f7174137fa0836808ad5166efbf22dc
+  React-defaultsnativemodule: deed608618274d6b9e395d0bb91925ec1384c827
+  React-domnativemodule: 8a7604a27a33d0b7ea3acd6ef5e556935af506a2
+  React-Fabric: e4f68a49e82aeb25e1f144d50ffa32dfb629cf16
+  React-FabricComponents: 7326b9ae2c2162033ba1d10713a2a6b0e762a990
+  React-FabricImage: e84692d44ac1a1c1560e86fad772449a033ef327
+  React-featureflags: 78f3d05ae8cbcfc3e26524954516fd1f8307d0ab
+  React-featureflagsnativemodule: c4f65ff56d5435db590214243e47cfdfdb7cf828
+  React-graphics: 394bd9e1311370733f770af9ba389e07e069a5d0
+  React-hermes: 9f44a83eca48842bd3f60fdc16bdb4fa29105eae
+  React-idlecallbacksnativemodule: 0ea88c4d02c347b18d8767bc85bda53e4d4821e8
+  React-ImageManager: 511d829cde144ba19a9b81007d1c44857d35c23e
+  React-intersectionobservernativemodule: 6fbd27810c75eac0beb09ea6b4d6fa8affd3c2d8
+  React-jserrorhandler: 695c432fcac6469bdfc28448a6315f84b58b18ec
+  React-jsi: 40bd06de577b224175f2ce5b4eb2cffa449c86df
+  React-jsiexecutor: 0c6068034234dd6910fa6d82f378f75bcc02a8b7
+  React-jsinspector: f1d093a0bc5cceb0c2d70a795208faf78135b4f9
+  React-jsinspectorcdp: 715b446a0e94cff9b3ee39131b39a58d707e96c5
+  React-jsinspectornetwork: 9c7351b59a5c05d095d797de8c5ad02f2e6e454c
+  React-jsinspectortracing: 464f0c731f7e9bb315073a1c3ea580feec29a07f
+  React-jsitooling: 08d95836603e386299044c72ce55a9e5ccd33be3
+  React-jsitracing: 3be389b754562dac073e4c167a010b9a91955417
+  React-logger: de0bd725e905e9be3ab919a4206666eec7c3e248
+  React-Mapbuffer: bfc59384f088a74c1cbe31902b5ba3d89c5947ce
+  React-microtasksnativemodule: 4e4a0a4e42861c767989099d02cd871dbe11736f
+  React-mutationobservernativemodule: 6aaa67618b68a616b1293967c20a1dfcc26632a5
+  react-native-bottom-tabs: be329013de6620585cd5e6ca6ac020223e31be3e
+  react-native-quick-base64: f5840b9dd6ea8f5814fee7a11376d709d08cab3a
+  react-native-safe-area-context: b3e671af6f52a4faaf7c1009a7a487bd9b551df0
+  react-native-vector-icons: 96005b208c80c31220245b202468887afab1fddc
   react-native-vector-icons-ionicons: 7e633927db6ab96e0255b5920c053777cacca505
-  react-native-worklets-core: 89a42b9bbce25698c6fb3f36fa61181377655e6c
-  React-NativeModulesApple: 167e532fb9bae30f3c66636b8ee0092bab263667
-  React-networking: 89f6b69755a3176f30e56ba1ba8e214b1518ecfb
+  react-native-worklets-core: ac6ca44cc93388211aa7da8977227f9ef8bb1faf
+  React-NativeModulesApple: f313ed47b56405d621e12ecda106a72020959ff3
+  React-networking: a0686d5a80eddbcd7bb702421fca503a76aacb1a
   React-oscompat: db6675ddaef3bddd1b41533627f3d26ec710c05f
-  React-perflogger: c34660c72849d23319f5e544c97e6c6ed687b186
-  React-performancecdpmetrics: 13ce0ca13d32007b7369f295c81bfad6316514bc
-  React-performancetimeline: b68271d5199dc356a80b661bb05622f5ed6777fb
+  React-perflogger: 21ca12b8deb8411c6fa4a564e6e4e0800390b556
+  React-performancecdpmetrics: 8497263114d72822f737e0b78aad26c85b2099bf
+  React-performancetimeline: bb4ca5f73f04b1074d2fe35dd574f30e58fbd733
   React-RCTActionSheet: 7d18777c531c516ab9f86342583057b15fb7fd7d
-  React-RCTAnimation: f2505067d2d83268f5619192f8f5ff14b2606c7f
-  React-RCTAppDelegate: 7bfa4d752f45a0b9195b8da0f188f8904806a86f
-  React-RCTBlob: 7b4d25eca2a6ecd83766d76790879774b73b4cd5
-  React-RCTFabric: a225895f3fd2b11f2c44b13229f2d99065eedda1
-  React-RCTFBReactNativeSpec: cb15356d207d325e689eca0c7b15d737aac8c6dc
-  React-RCTImage: 9123b010921479b5bcd3771a4a4d4e788227a427
-  React-RCTLinking: 358d42629d7012c5d75060fd3e25023b72ebae31
-  React-RCTNetwork: 32f5274abd61e937bdcbfd85810ae784d3f0e38a
-  React-RCTRuntime: b11ef93babc2be36f5e10835d246e0e623f6570b
-  React-RCTSettings: 86aa6e6a3a335d989e3fcd1bd98b9ea6331adfa9
-  React-RCTText: 59376611225f3c6fdc75d57571d7c345bdd0be1e
-  React-RCTVibration: 3c7d17d3373c114220be9ac3b99df1646009b8fe
+  React-RCTAnimation: 14a2fdc1165d73dc96abd0935e89c2127a119fbd
+  React-RCTAppDelegate: 0b5a06df526fe79b2a5cbe90b889e28867e14574
+  React-RCTBlob: f2ebb238c43a631f541377ec18ed60bb70665363
+  React-RCTFabric: 231d533ee1d4eb9db9f876ad8c25878794b53724
+  React-RCTFBReactNativeSpec: 679afd98830c2cb6cb7a0c31763012cbc74fa486
+  React-RCTImage: 1d8c5b8786a0f52d0d2613b8ba58c02c1da67c1e
+  React-RCTLinking: 2560d59e85c82f260bff81fffc4ea30bc66a500b
+  React-RCTNetwork: d331a823911e70fd1de7eeddaa739f4c54dcacc4
+  React-RCTRuntime: b1cc28447a887ac6f1b1d383d93d1f9360b1b6e8
+  React-RCTSettings: b7896598aa87af4b907628164240e87457e6f830
+  React-RCTText: 1eb82d0798487adcf394a12d8fad825722d1a376
+  React-RCTVibration: 0c76a15901bb1c8d47a8a02dc16f95f39ed3ffb5
   React-rendererconsistency: c9a2d2351407696ccbefdeb53b4aee109c4cb008
-  React-renderercss: 883aebdf574736450571800eeb3edbc804385c76
-  React-rendererdebug: fc1e330efedfd4dfe4fd7d75736f9a219dae196f
-  React-RuntimeApple: f099a47224222ddfc7ddaffdd9aa2ac47a216ee0
-  React-RuntimeCore: e91b17661cc543f4a241e69b3f038182d7db8fd6
-  React-runtimeexecutor: d27e321bd8e04d4737bc8924473a25defb33a031
-  React-RuntimeHermes: 760a0793748cb12b4dd11f323bd516668b7e3b99
-  React-runtimescheduler: df1c84ed1a5b78a1a7953d3e86db6163c4542906
-  React-timing: 791690a2daa7b13554060f6836c260c8bc311a98
-  React-utils: 13f4f227561d2660201dee5cbea253c07d8b5d3a
-  React-viewtransitionnativemodule: 93335dacae2dd7db207320f384111c2b4c58fca8
-  React-webperformancenativemodule: 0bed183d6447493571431c031ad2401c027b5866
-  ReactAppDependencyProvider: 0e13d430eadac8a2ef18515a860d5c59df05b475
-  ReactCodegen: 8f2b77e96bcb03fe939d567a067fb097618227a1
-  ReactCommon: 9002f006f571256348994183f7d4387aa7cf84e8
-  ReactNativeBottomSheet: 63aa348b5cc4cd101613c8ffa70163056043c0a5
+  React-renderercss: f47a328de59fa4f6a86900e9c57533aae3a9c02f
+  React-rendererdebug: d160cfa801014fb69206f0b4cde4c1e78805b766
+  React-RuntimeApple: bdfe33451e5ad94bb6cda9f259da6682f0da2e83
+  React-RuntimeCore: 5924b98279f2729b50b34a59f379d8bdd66425e6
+  React-runtimeexecutor: 1d8152478961e2eba5137d6cfeaf44037e84974d
+  React-RuntimeHermes: 93211f1da41bee7a5a5b4095b47504beffae98de
+  React-runtimescheduler: 4cd060f43d1bfb03b30ad876925e018ca0f89f0e
+  React-timing: 3e175c2d74410262027458380950122a18b1edf0
+  React-utils: 9e3bc5d5f28e4333605df0d6cd5873ea29936715
+  React-viewtransitionnativemodule: 6958f31ac3ed27ccb4da3446d4041da111b63949
+  React-webperformancenativemodule: a52e599962a9be3c06ed00470e71e3c3d94f942f
+  ReactAppDependencyProvider: 082ef199e27011a4314f499b6b2e2ac29e141267
+  ReactCodegen: 8e49c676243a256aad599bfddb31a05fe6c93b43
+  ReactCommon: 00d8d68c7aa036745334d3a3844102ecd9bf099d
+  ReactNativeBottomSheet: ad86e071a3993700fec5d394314cdaf5445f00c9
   ReactNativeDependencies: 2bd6854ade79bf1b60586d1ab7813a389df1b6bf
-  RNCClipboard: 715fa7c6c8366f17d00f05a439ee7488f390fa5f
-  RNFSTurbo: 2ba3f628bad433250a545a8c156529866f01d4da
-  RNGestureHandler: 92172e79df6e88e0e93b6341f9dcd8b5a02746ba
-  RNKeychain: 6778b35b5bd067c322f8479526ac09b1d61f31d0
-  RNReanimated: dbc78e86e5782811ebbfb8f492abfbc744486666
-  RNScreens: 7118cd7715c226856125b5bece3c4d9abec90356
-  RNSentry: c2b739c5dbdd77f439fbd197d1d45724b22a0437
-  RNShare: 7344a3a7d4e5df58c356ad0f79e4a3ef1325c635
-  RNSVG: 6cae8d4082913be2eb43eaec2a456222c42195ed
-  RNWorklets: bb6f040dd3a46ef34d7e9ca51d4c7d1b804c190c
+  RNCClipboard: c1cdf3cdd72df606520114f42e61c6898a488dd8
+  RNFSTurbo: d00626ccbeb66c229d14fa1ba33adc3d2f12caab
+  RNGestureHandler: a21ad1bb32b203570440c29b7e406a342a690842
+  RNKeychain: 1b055a0ec36d058cb0a075e965d8c9d335e0c828
+  RNReanimated: e08985a3c8d955369bb043223b59222ae02acd1b
+  RNScreens: dcd5c85a822d9cbb21fc321bbbbcf918f3d48c23
+  RNSentry: 859c1702fe09e25c24747a5feedecab1d5138074
+  RNShare: 43cee010ada075019148c7a6bac1ca71b074e1d7
+  RNSVG: ffe18ba0e8fbad864bf22d6f0060a4ee88ec9bf3
+  RNWorklets: dd252c27100f818fda50e14251450fb12ea17f06
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageSVGCoder: 8e10c8f6cc879c7dfb317b284e13dd589379f01c
   Sentry: d587a8fe91ca13503ecd69a1905f3e8a0fcf61be
   SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d
-  UMAppLoader: 173cb90a3039aa9c1b84bace4487e1907a4a5a39
-  VisionCamera: 0044a94f7489f19e19d5938e97dfc36f4784af3c
+  UMAppLoader: 0e242f0ae19297f8f1a4ae730c91d545ffd3e2cc
+  VisionCamera: 47f10351a1b6a8d251b90986ae72ca5f52331954
   Yoga: 9891cfb1c680f64de9c41b09e7453dea33454d2b
   ZIPFoundation: dfd3d681c4053ff7e2f7350bc4e53b5dba3f5351
 

--- a/client/ios/noah/PrivacyInfo.xcprivacy
+++ b/client/ios/noah/PrivacyInfo.xcprivacy
@@ -36,8 +36,8 @@
 			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>85F4.1</string>
 				<string>E174.1</string>
+				<string>85F4.1</string>
 			</array>
 		</dict>
 	</array>

--- a/client/src/components/ReceiveAmountBottomSheet.tsx
+++ b/client/src/components/ReceiveAmountBottomSheet.tsx
@@ -1,0 +1,299 @@
+import Icon from "@react-native-vector-icons/ionicons";
+import { useEffect, useState } from "react";
+import { Pressable, TextInput, View } from "react-native";
+
+import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
+import { NativeNoahSecondaryButton } from "~/components/ui/NativeNoahSecondaryButton";
+import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
+import { Text } from "~/components/ui/text";
+import { useBitcoinAmountFormatter, useBitcoinAmountUnit } from "~/hooks/useBitcoinAmountFormatter";
+import { useReceiveScreen } from "~/hooks/useReceiveScreen";
+import { useThemeColors } from "~/hooks/useTheme";
+import { formatFiatAmount, getFiatCurrencyInfo, satsToFiat } from "~/lib/fiatCurrency";
+import {
+  getInvoiceDescriptionLength,
+  isInvoiceDescriptionValid,
+  MAX_INVOICE_DESCRIPTION_LENGTH,
+} from "~/lib/lightningInvoice";
+import { COLORS } from "~/lib/styleConstants";
+import { formatNumber } from "~/lib/utils";
+
+type ReceiveAmountBottomSheetProps = {
+  initialAmountSat: number | null;
+  initialDescription: string;
+  isOpen: boolean;
+  isSubmitting: boolean;
+  onClose: () => void;
+  onRemove: () => void;
+  onSubmit: (request: { amountSat: number; description: string }) => void;
+};
+
+type KeypadKey = "backspace" | "." | `${number}`;
+
+const KEYPAD_ROWS: KeypadKey[][] = [
+  ["1", "2", "3"],
+  ["4", "5", "6"],
+  ["7", "8", "9"],
+  [".", "0", "backspace"],
+];
+
+const MAX_AMOUNT_LENGTH = 12;
+
+export function ReceiveAmountBottomSheet({
+  initialAmountSat,
+  initialDescription,
+  isOpen,
+  isSubmitting,
+  onClose,
+  onRemove,
+  onSubmit,
+}: ReceiveAmountBottomSheetProps) {
+  const colors = useThemeColors();
+  const bitcoinAmountUnit = useBitcoinAmountUnit();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
+  const {
+    amount,
+    amountSat,
+    btcPrice,
+    currency,
+    fiatCurrency,
+    setAmount,
+    setCurrency,
+    toggleCurrency,
+  } = useReceiveScreen();
+  const fiatCurrencyInfo = getFiatCurrencyInfo(fiatCurrency);
+  const [description, setDescription] = useState("");
+  const [isNoteVisible, setIsNoteVisible] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setCurrency("SATS");
+    setAmount(initialAmountSat?.toString() ?? "");
+    setDescription(initialDescription);
+    setIsNoteVisible(initialDescription.length > 0);
+  }, [initialAmountSat, initialDescription, isOpen, setAmount, setCurrency]);
+
+  const descriptionLength = getInvoiceDescriptionLength(description);
+  const isDescriptionValid = isInvoiceDescriptionValid(description);
+  const canSubmit = Number.isInteger(amountSat) && amountSat > 0 && isDescriptionValid;
+  const displayAmount = amount.length === 0 ? "0" : formatNumber(amount);
+  const amountPrefix =
+    currency === "FIAT" ? fiatCurrencyInfo.symbol : bitcoinAmountUnit === "bip177" ? "₿" : null;
+  const amountSuffix = currency === "SATS" && bitcoinAmountUnit === "sats" ? "sats" : null;
+  const convertedAmount =
+    currency === "SATS"
+      ? btcPrice
+        ? formatFiatAmount(satsToFiat(amountSat, btcPrice, fiatCurrency), fiatCurrency)
+        : `${fiatCurrencyInfo.code} rate unavailable`
+      : formatBitcoinAmount(amountSat);
+
+  const close = () => {
+    if (!isSubmitting) {
+      onClose();
+    }
+  };
+
+  const enterKey = (key: KeypadKey) => {
+    if (isSubmitting) {
+      return;
+    }
+
+    if (key === "backspace") {
+      setAmount(amount.slice(0, -1));
+      return;
+    }
+
+    if (key === ".") {
+      if (currency !== "FIAT" || fiatCurrencyInfo.decimals === 0 || amount.includes(".")) {
+        return;
+      }
+
+      setAmount(amount.length === 0 ? "0." : `${amount}.`);
+      return;
+    }
+
+    if (amount.length >= MAX_AMOUNT_LENGTH) {
+      return;
+    }
+
+    const decimalPlaces = amount.split(".")[1]?.length ?? 0;
+    if (currency === "FIAT" && amount.includes(".") && decimalPlaces >= fiatCurrencyInfo.decimals) {
+      return;
+    }
+
+    setAmount(amount === "0" ? key : `${amount}${key}`);
+  };
+
+  const submit = () => {
+    if (!canSubmit || isSubmitting) {
+      return;
+    }
+
+    onSubmit({ amountSat, description: description.trim() });
+  };
+
+  return (
+    <AppBottomSheet isOpen={isOpen} onClose={close} avoidKeyboard>
+      <View className="flex-1 pb-4">
+        <View className="flex-row items-center justify-between">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Close amount entry"
+            accessibilityState={{ disabled: isSubmitting }}
+            disabled={isSubmitting}
+            onPress={close}
+            className="h-12 w-12 items-center justify-center rounded-full border border-border"
+          >
+            <Icon name="close" size={24} color={colors.foreground} />
+          </Pressable>
+
+          {isNoteVisible ? (
+            <Text className="text-sm font-semibold text-muted-foreground">Lightning note</Text>
+          ) : (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Add a Lightning note"
+              onPress={() => setIsNoteVisible(true)}
+              className="rounded-full border border-border bg-card px-5 py-3"
+            >
+              <Text className="font-semibold text-foreground">Add a note</Text>
+            </Pressable>
+          )}
+
+          <View className="h-12 w-12" />
+        </View>
+
+        {isNoteVisible ? (
+          <View className="mt-4">
+            <TextInput
+              accessibilityLabel="Lightning note"
+              autoFocus={initialDescription.length === 0}
+              className="rounded-2xl border border-border bg-card px-4 py-4 text-base text-foreground"
+              editable={!isSubmitting}
+              maxLength={MAX_INVOICE_DESCRIPTION_LENGTH}
+              onChangeText={setDescription}
+              placeholder="What is this payment for?"
+              placeholderTextColor={colors.mutedForeground}
+              returnKeyType="done"
+              value={description}
+            />
+            <Text
+              className={`mt-2 text-right text-xs ${
+                isDescriptionValid ? "text-muted-foreground" : "text-destructive"
+              }`}
+            >
+              {descriptionLength}/{MAX_INVOICE_DESCRIPTION_LENGTH}
+            </Text>
+          </View>
+        ) : null}
+
+        <View className="flex-1 items-center justify-center py-5">
+          <View
+            accessibilityRole="text"
+            accessibilityLabel={`${amount.length === 0 ? "0" : amount} ${
+              currency === "SATS" ? "sats" : fiatCurrency
+            }`}
+            className="flex-row items-baseline justify-center px-4"
+          >
+            {amountPrefix ? (
+              <Text className="mr-2 text-[56px] font-bold leading-[64px] text-foreground">
+                {amountPrefix}
+              </Text>
+            ) : null}
+            <Text
+              adjustsFontSizeToFit
+              className="max-w-[260px] text-[56px] font-bold leading-[64px] text-foreground"
+              minimumFontScale={0.55}
+              numberOfLines={1}
+            >
+              {displayAmount}
+            </Text>
+            {amountSuffix ? (
+              <Text className="ml-2 text-xl font-semibold text-muted-foreground">
+                {amountSuffix}
+              </Text>
+            ) : null}
+          </View>
+
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Switch to ${currency === "SATS" ? fiatCurrency : "sats"}`}
+            accessibilityState={{ disabled: !btcPrice || isSubmitting }}
+            disabled={!btcPrice || isSubmitting}
+            onPress={toggleCurrency}
+            className="mt-3 flex-row items-center gap-2 px-4 py-2"
+          >
+            <Text
+              className="text-base font-semibold"
+              style={{ color: btcPrice ? COLORS.SUCCESS : colors.mutedForeground }}
+            >
+              {convertedAmount}
+            </Text>
+            <Icon
+              name="swap-vertical"
+              size={18}
+              color={btcPrice ? COLORS.SUCCESS : colors.mutedForeground}
+            />
+          </Pressable>
+        </View>
+
+        <View accessibilityLabel="Amount keypad" className="mb-5">
+          {KEYPAD_ROWS.map((row, rowIndex) => (
+            <View key={rowIndex} className="flex-row">
+              {row.map((key) => {
+                const isDecimalDisabled =
+                  key === "." && (currency !== "FIAT" || fiatCurrencyInfo.decimals === 0);
+
+                return (
+                  <Pressable
+                    key={key}
+                    accessibilityRole="button"
+                    accessibilityLabel={key === "backspace" ? "Delete digit" : key}
+                    accessibilityState={{ disabled: isDecimalDisabled || isSubmitting }}
+                    disabled={isDecimalDisabled || isSubmitting}
+                    onPress={() => enterKey(key)}
+                    className="h-[66px] flex-1 items-center justify-center"
+                    testID={`receive-key-${key}`}
+                  >
+                    {key === "backspace" ? (
+                      <Icon name="backspace-outline" size={27} color={colors.foreground} />
+                    ) : isDecimalDisabled ? null : (
+                      <Text className="text-3xl font-medium text-foreground">{key}</Text>
+                    )}
+                  </Pressable>
+                );
+              })}
+            </View>
+          ))}
+        </View>
+
+        <NativeNoahButton
+          label={initialAmountSat === null ? "Next" : "Update request"}
+          loadingLabel="Generating…"
+          onPress={submit}
+          disabled={!canSubmit}
+          isLoading={isSubmitting}
+          size="lg"
+          fullWidth
+          testID="receive-amount-submit"
+        />
+
+        {initialAmountSat !== null ? (
+          <NativeNoahSecondaryButton
+            label="Remove amount"
+            onPress={onRemove}
+            disabled={isSubmitting}
+            emphasis="ghost"
+            tone="destructive"
+            className="mt-2"
+            fullWidth
+            testID="receive-amount-remove"
+          />
+        ) : null}
+      </View>
+    </AppBottomSheet>
+  );
+}

--- a/client/src/components/ReceiveAmountBottomSheet.tsx
+++ b/client/src/components/ReceiveAmountBottomSheet.tsx
@@ -1,6 +1,6 @@
 import Icon from "@react-native-vector-icons/ionicons";
 import { useEffect, useState } from "react";
-import { Pressable, TextInput, View } from "react-native";
+import { Keyboard, Pressable, TextInput, View } from "react-native";
 
 import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
 import { NativeNoahSecondaryButton } from "~/components/ui/NativeNoahSecondaryButton";
@@ -63,7 +63,8 @@ export function ReceiveAmountBottomSheet({
   } = useReceiveScreen();
   const fiatCurrencyInfo = getFiatCurrencyInfo(fiatCurrency);
   const [description, setDescription] = useState("");
-  const [isNoteVisible, setIsNoteVisible] = useState(false);
+  const [noteDraft, setNoteDraft] = useState("");
+  const [isEditingNote, setIsEditingNote] = useState(false);
 
   useEffect(() => {
     if (!isOpen) {
@@ -73,15 +74,22 @@ export function ReceiveAmountBottomSheet({
     setCurrency("SATS");
     setAmount(initialAmountSat?.toString() ?? "");
     setDescription(initialDescription);
-    setIsNoteVisible(initialDescription.length > 0);
+    setNoteDraft(initialDescription);
+    setIsEditingNote(false);
   }, [initialAmountSat, initialDescription, isOpen, setAmount, setCurrency]);
 
-  const descriptionLength = getInvoiceDescriptionLength(description);
   const isDescriptionValid = isInvoiceDescriptionValid(description);
+  const noteDraftLength = getInvoiceDescriptionLength(noteDraft);
+  const isNoteDraftValid = isInvoiceDescriptionValid(noteDraft);
+  const canSaveNote =
+    isNoteDraftValid && (noteDraft.trim().length > 0 || description.trim().length > 0);
   const canSubmit = Number.isInteger(amountSat) && amountSat > 0 && isDescriptionValid;
   const displayAmount = amount.length === 0 ? "0" : formatNumber(amount);
   const amountPrefix =
     currency === "FIAT" ? fiatCurrencyInfo.symbol : bitcoinAmountUnit === "bip177" ? "₿" : null;
+  const primaryAmount = amountPrefix ? `${amountPrefix}${displayAmount}` : displayAmount;
+  const primaryAmountFontSize =
+    primaryAmount.length <= 7 ? 56 : primaryAmount.length <= 10 ? 44 : 34;
   const amountSuffix = currency === "SATS" && bitcoinAmountUnit === "sats" ? "sats" : null;
   const convertedAmount =
     currency === "SATS"
@@ -92,8 +100,30 @@ export function ReceiveAmountBottomSheet({
 
   const close = () => {
     if (!isSubmitting) {
+      Keyboard.dismiss();
       onClose();
     }
+  };
+
+  const openNoteEditor = () => {
+    setNoteDraft(description);
+    setIsEditingNote(true);
+  };
+
+  const closeNoteEditor = () => {
+    Keyboard.dismiss();
+    setNoteDraft(description);
+    setIsEditingNote(false);
+  };
+
+  const saveNote = () => {
+    if (!canSaveNote || isSubmitting) {
+      return;
+    }
+
+    Keyboard.dismiss();
+    setDescription(noteDraft.trim());
+    setIsEditingNote(false);
   };
 
   const enterKey = (key: KeypadKey) => {
@@ -136,164 +166,199 @@ export function ReceiveAmountBottomSheet({
   };
 
   return (
-    <AppBottomSheet isOpen={isOpen} onClose={close} avoidKeyboard>
-      <View className="flex-1 pb-4">
-        <View className="flex-row items-center justify-between">
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Close amount entry"
-            accessibilityState={{ disabled: isSubmitting }}
-            disabled={isSubmitting}
-            onPress={close}
-            className="h-12 w-12 items-center justify-center rounded-full border border-border"
-          >
-            <Icon name="close" size={24} color={colors.foreground} />
-          </Pressable>
-
-          {isNoteVisible ? (
-            <Text className="text-sm font-semibold text-muted-foreground">Lightning note</Text>
-          ) : (
+    <AppBottomSheet isOpen={isOpen} onClose={close}>
+      {isEditingNote ? (
+        <View className="flex-1">
+          <View className="flex-row items-center justify-between">
             <Pressable
               accessibilityRole="button"
-              accessibilityLabel="Add a Lightning note"
-              onPress={() => setIsNoteVisible(true)}
-              className="rounded-full border border-border bg-card px-5 py-3"
+              accessibilityLabel="Close note editor"
+              onPress={closeNoteEditor}
+              className="h-12 w-12 items-center justify-center rounded-full border border-border"
             >
-              <Text className="font-semibold text-foreground">Add a note</Text>
+              <Icon name="close" size={24} color={colors.foreground} />
             </Pressable>
-          )}
+            <View className="h-12 w-12" />
+          </View>
 
-          <View className="h-12 w-12" />
-        </View>
+          <Text
+            accessibilityRole="header"
+            className="mt-8 text-2xl font-bold leading-8 text-foreground"
+          >
+            What is the payment for?
+          </Text>
 
-        {isNoteVisible ? (
-          <View className="mt-4">
-            <TextInput
-              accessibilityLabel="Lightning note"
-              autoFocus={initialDescription.length === 0}
-              className="rounded-2xl border border-border bg-card px-4 py-4 text-base text-foreground"
-              editable={!isSubmitting}
-              maxLength={MAX_INVOICE_DESCRIPTION_LENGTH}
-              onChangeText={setDescription}
-              placeholder="What is this payment for?"
-              placeholderTextColor={colors.mutedForeground}
-              returnKeyType="done"
-              value={description}
-            />
+          <TextInput
+            accessibilityLabel="Lightning note"
+            autoFocus
+            className="mt-8 rounded-2xl border border-foreground bg-background px-5 py-4 text-lg text-foreground"
+            editable={!isSubmitting}
+            maxLength={MAX_INVOICE_DESCRIPTION_LENGTH}
+            onChangeText={setNoteDraft}
+            onSubmitEditing={saveNote}
+            placeholder="Your note"
+            placeholderTextColor={colors.mutedForeground}
+            returnKeyType="done"
+            testID="receive-note-input"
+            value={noteDraft}
+          />
+          {noteDraftLength >= MAX_INVOICE_DESCRIPTION_LENGTH - 40 || !isNoteDraftValid ? (
             <Text
-              className={`mt-2 text-right text-xs ${
-                isDescriptionValid ? "text-muted-foreground" : "text-destructive"
+              className={`mt-2 text-right text-sm ${
+                isNoteDraftValid ? "text-muted-foreground" : "text-destructive"
               }`}
             >
-              {descriptionLength}/{MAX_INVOICE_DESCRIPTION_LENGTH}
+              {noteDraftLength}/{MAX_INVOICE_DESCRIPTION_LENGTH}
             </Text>
-          </View>
-        ) : null}
+          ) : null}
 
-        <View className="flex-1 items-center justify-center py-5">
-          <View
-            accessibilityRole="text"
-            accessibilityLabel={`${amount.length === 0 ? "0" : amount} ${
-              currency === "SATS" ? "sats" : fiatCurrency
-            }`}
-            className="flex-row items-baseline justify-center px-4"
-          >
-            {amountPrefix ? (
-              <Text className="mr-2 text-[56px] font-bold leading-[64px] text-foreground">
-                {amountPrefix}
-              </Text>
-            ) : null}
-            <Text
-              adjustsFontSizeToFit
-              className="max-w-[260px] text-[56px] font-bold leading-[64px] text-foreground"
-              minimumFontScale={0.55}
-              numberOfLines={1}
-            >
-              {displayAmount}
-            </Text>
-            {amountSuffix ? (
-              <Text className="ml-2 text-xl font-semibold text-muted-foreground">
-                {amountSuffix}
-              </Text>
-            ) : null}
-          </View>
-
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={`Switch to ${currency === "SATS" ? fiatCurrency : "sats"}`}
-            accessibilityState={{ disabled: !btcPrice || isSubmitting }}
-            disabled={!btcPrice || isSubmitting}
-            onPress={toggleCurrency}
-            className="mt-3 flex-row items-center gap-2 px-4 py-2"
-          >
-            <Text
-              className="text-base font-semibold"
-              style={{ color: btcPrice ? COLORS.SUCCESS : colors.mutedForeground }}
-            >
-              {convertedAmount}
-            </Text>
-            <Icon
-              name="swap-vertical"
-              size={18}
-              color={btcPrice ? COLORS.SUCCESS : colors.mutedForeground}
+          <View className="mt-6 px-1">
+            <NativeNoahButton
+              label="Done"
+              onPress={saveNote}
+              disabled={!canSaveNote}
+              size="lg"
+              fullWidth
+              testID="receive-note-done"
             />
-          </Pressable>
+          </View>
         </View>
+      ) : (
+        <View className="flex-1">
+          <View className="flex-row items-center justify-between">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Close amount entry"
+              accessibilityState={{ disabled: isSubmitting }}
+              disabled={isSubmitting}
+              onPress={close}
+              className="h-12 w-12 items-center justify-center rounded-full border border-border"
+            >
+              <Icon name="close" size={24} color={colors.foreground} />
+            </Pressable>
 
-        <View accessibilityLabel="Amount keypad" className="mb-5">
-          {KEYPAD_ROWS.map((row, rowIndex) => (
-            <View key={rowIndex} className="flex-row">
-              {row.map((key) => {
-                const isDecimalDisabled =
-                  key === "." && (currency !== "FIAT" || fiatCurrencyInfo.decimals === 0);
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={description ? "Edit Lightning note" : "Add a Lightning note"}
+              accessibilityState={{ disabled: isSubmitting }}
+              disabled={isSubmitting}
+              onPress={openNoteEditor}
+              className="rounded-full border border-border bg-card px-5 py-3"
+              testID="receive-note-button"
+            >
+              <Text className="font-semibold text-foreground">
+                {description ? "Edit note" : "Add a note"}
+              </Text>
+            </Pressable>
 
-                return (
-                  <Pressable
-                    key={key}
-                    accessibilityRole="button"
-                    accessibilityLabel={key === "backspace" ? "Delete digit" : key}
-                    accessibilityState={{ disabled: isDecimalDisabled || isSubmitting }}
-                    disabled={isDecimalDisabled || isSubmitting}
-                    onPress={() => enterKey(key)}
-                    className="h-[66px] flex-1 items-center justify-center"
-                    testID={`receive-key-${key}`}
-                  >
-                    {key === "backspace" ? (
-                      <Icon name="backspace-outline" size={27} color={colors.foreground} />
-                    ) : isDecimalDisabled ? null : (
-                      <Text className="text-3xl font-medium text-foreground">{key}</Text>
-                    )}
-                  </Pressable>
-                );
-              })}
+            <View className="h-12 w-12" />
+          </View>
+
+          <View className="flex-1 items-center justify-center py-5">
+            <View
+              accessibilityRole="text"
+              accessibilityLabel={`${amount.length === 0 ? "0" : amount} ${
+                currency === "SATS" ? "sats" : fiatCurrency
+              }`}
+              className="flex-row items-baseline justify-center px-4"
+            >
+              <Text
+                className="text-center font-bold text-foreground"
+                numberOfLines={1}
+                style={{
+                  width: amountSuffix ? 250 : 320,
+                  fontSize: primaryAmountFontSize,
+                  lineHeight: primaryAmountFontSize + 8,
+                }}
+              >
+                {primaryAmount}
+              </Text>
+              {amountSuffix ? (
+                <Text className="ml-2 text-xl font-semibold text-muted-foreground">
+                  {amountSuffix}
+                </Text>
+              ) : null}
             </View>
-          ))}
+
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={`Switch to ${currency === "SATS" ? fiatCurrency : "sats"}`}
+              accessibilityState={{ disabled: !btcPrice || isSubmitting }}
+              disabled={!btcPrice || isSubmitting}
+              onPress={toggleCurrency}
+              className="mt-2 flex-row items-center gap-2 px-4 py-2"
+            >
+              <Text
+                className="text-xl font-semibold leading-7"
+                style={{ color: btcPrice ? COLORS.SUCCESS : colors.mutedForeground }}
+              >
+                {convertedAmount}
+              </Text>
+              <Icon
+                name="swap-vertical"
+                size={21}
+                color={btcPrice ? COLORS.SUCCESS : colors.mutedForeground}
+              />
+            </Pressable>
+          </View>
+
+          <View accessibilityLabel="Amount keypad" className="mb-5">
+            {KEYPAD_ROWS.map((row, rowIndex) => (
+              <View key={rowIndex} className="flex-row">
+                {row.map((key) => {
+                  const isDecimalDisabled =
+                    key === "." && (currency !== "FIAT" || fiatCurrencyInfo.decimals === 0);
+
+                  return (
+                    <Pressable
+                      key={key}
+                      accessibilityRole="button"
+                      accessibilityLabel={key === "backspace" ? "Delete digit" : key}
+                      accessibilityState={{ disabled: isDecimalDisabled || isSubmitting }}
+                      disabled={isDecimalDisabled || isSubmitting}
+                      onPress={() => enterKey(key)}
+                      className="h-[66px] flex-1 items-center justify-center"
+                      testID={`receive-key-${key}`}
+                    >
+                      {key === "backspace" ? (
+                        <Icon name="backspace-outline" size={27} color={colors.foreground} />
+                      ) : isDecimalDisabled ? null : (
+                        <Text className="text-3xl font-medium text-foreground">{key}</Text>
+                      )}
+                    </Pressable>
+                  );
+                })}
+              </View>
+            ))}
+          </View>
+
+          <View className="px-1">
+            <NativeNoahButton
+              label={initialAmountSat === null ? "Next" : "Update request"}
+              loadingLabel="Generating…"
+              onPress={submit}
+              disabled={!canSubmit}
+              isLoading={isSubmitting}
+              size="lg"
+              fullWidth
+              testID="receive-amount-submit"
+            />
+          </View>
+
+          {initialAmountSat !== null ? (
+            <NativeNoahSecondaryButton
+              label="Remove amount"
+              onPress={onRemove}
+              disabled={isSubmitting}
+              emphasis="ghost"
+              tone="destructive"
+              className="mt-2"
+              fullWidth
+              testID="receive-amount-remove"
+            />
+          ) : null}
         </View>
-
-        <NativeNoahButton
-          label={initialAmountSat === null ? "Next" : "Update request"}
-          loadingLabel="Generating…"
-          onPress={submit}
-          disabled={!canSubmit}
-          isLoading={isSubmitting}
-          size="lg"
-          fullWidth
-          testID="receive-amount-submit"
-        />
-
-        {initialAmountSat !== null ? (
-          <NativeNoahSecondaryButton
-            label="Remove amount"
-            onPress={onRemove}
-            disabled={isSubmitting}
-            emphasis="ghost"
-            tone="destructive"
-            className="mt-2"
-            fullWidth
-            testID="receive-amount-remove"
-          />
-        ) : null}
-      </View>
+      )}
     </AppBottomSheet>
   );
 }

--- a/client/src/components/ReceiveCopyBottomSheet.tsx
+++ b/client/src/components/ReceiveCopyBottomSheet.tsx
@@ -86,7 +86,7 @@ export function ReceiveCopyBottomSheet({
 
   return (
     <AppBottomSheet isOpen={isOpen} onClose={onClose} detents={[0, "content"]}>
-      <View className="pb-4">
+      <View>
         <View className="flex-row items-start justify-between gap-4">
           <View className="flex-1">
             <Text accessibilityRole="header" className="text-2xl font-bold text-foreground">

--- a/client/src/components/ReceiveCopyBottomSheet.tsx
+++ b/client/src/components/ReceiveCopyBottomSheet.tsx
@@ -1,0 +1,158 @@
+import Icon from "@react-native-vector-icons/ionicons";
+import type { ReactNode } from "react";
+import { AccessibilityInfo, Pressable, View } from "react-native";
+
+import { ArkIcon } from "~/lib/icons/Ark";
+import { LightningIcon } from "~/lib/icons/Lightning";
+import { OnchainIcon } from "~/lib/icons/Onchain";
+import { useCopyToClipboard } from "~/lib/clipboardUtils";
+import { COLORS } from "~/lib/styleConstants";
+import { useThemeColors } from "~/hooks/useTheme";
+import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
+import { Text } from "~/components/ui/text";
+
+type ReceiveCopyBottomSheetProps = {
+  arkAddress: string;
+  bip321Uri: string;
+  isOpen: boolean;
+  lightningInvoice?: string;
+  onClose: () => void;
+  onchainAddress: string;
+};
+
+type CopyOption = {
+  id: "request" | "ark" | "lightning" | "onchain";
+  icon: ReactNode;
+  label: string;
+  value: string;
+};
+
+const truncateValue = (value: string) => {
+  if (value.length <= 42) {
+    return value;
+  }
+
+  return `${value.slice(0, 18)}…${value.slice(-14)}`;
+};
+
+export function ReceiveCopyBottomSheet({
+  arkAddress,
+  bip321Uri,
+  isOpen,
+  lightningInvoice,
+  onClose,
+  onchainAddress,
+}: ReceiveCopyBottomSheetProps) {
+  const colors = useThemeColors();
+  const { copyWithState, isCopied } = useCopyToClipboard();
+  const options: CopyOption[] = [
+    {
+      id: "request",
+      icon: <Icon name="qr-code-outline" size={20} color={colors.foreground} />,
+      label: "Payment request",
+      value: bip321Uri,
+    },
+    {
+      id: "ark",
+      icon: <ArkIcon className="h-5 w-5 text-foreground" />,
+      label: "Ark",
+      value: arkAddress,
+    },
+    ...(lightningInvoice
+      ? [
+          {
+            id: "lightning" as const,
+            icon: <LightningIcon className="h-5 w-5 text-foreground" />,
+            label: "Lightning",
+            value: lightningInvoice,
+          },
+        ]
+      : []),
+    {
+      id: "onchain",
+      icon: <OnchainIcon className="h-5 w-5 text-foreground" />,
+      label: "On-chain",
+      value: onchainAddress,
+    },
+  ];
+
+  const copyOption = (option: CopyOption) => {
+    void copyWithState(option.value, option.id, {
+      onCopy: () => {
+        AccessibilityInfo.announceForAccessibility(`${option.label} copied`);
+      },
+    });
+  };
+
+  return (
+    <AppBottomSheet isOpen={isOpen} onClose={onClose} detents={[0, "content"]}>
+      <View className="pb-4">
+        <View className="flex-row items-start justify-between gap-4">
+          <View className="flex-1">
+            <Text accessibilityRole="header" className="text-2xl font-bold text-foreground">
+              Copy payment details
+            </Text>
+            <Text className="mt-2 text-sm leading-5 text-muted-foreground">
+              Copy the unified request or a specific payment method.
+            </Text>
+          </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Close payment details"
+            onPress={onClose}
+            className="h-11 w-11 items-center justify-center rounded-full border border-border"
+          >
+            <Icon name="close" size={22} color={colors.foreground} />
+          </Pressable>
+        </View>
+
+        <View className="mt-5 overflow-hidden rounded-[22px] border border-border bg-card">
+          {options.map((option, index) => {
+            const copied = isCopied(option.id);
+
+            return (
+              <Pressable
+                key={option.id}
+                accessibilityRole="button"
+                accessibilityLabel={copied ? `${option.label} copied` : `Copy ${option.label}`}
+                onPress={() => copyOption(option)}
+                className={`flex-row items-center gap-4 px-4 py-4 ${
+                  index < options.length - 1 ? "border-b border-border" : ""
+                }`}
+                testID={`receive-copy-${option.id}`}
+              >
+                <View className="h-11 w-11 items-center justify-center rounded-full bg-primary/10">
+                  {option.icon}
+                </View>
+                <View className="flex-1">
+                  <Text className="text-base font-semibold text-foreground">{option.label}</Text>
+                  <Text
+                    className="mt-1 text-sm text-muted-foreground"
+                    numberOfLines={1}
+                    ellipsizeMode="middle"
+                  >
+                    {truncateValue(option.value)}
+                  </Text>
+                </View>
+                <View className="items-center gap-1">
+                  <Icon
+                    name={copied ? "checkmark-circle" : "copy-outline"}
+                    size={21}
+                    color={copied ? COLORS.SUCCESS : COLORS.BITCOIN_ORANGE}
+                  />
+                  <Text
+                    accessibilityLiveRegion="polite"
+                    className="text-[11px] font-semibold"
+                    style={{ color: copied ? COLORS.SUCCESS : COLORS.BITCOIN_ORANGE }}
+                  >
+                    {copied ? "Copied" : "Copy"}
+                  </Text>
+                </View>
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+    </AppBottomSheet>
+  );
+}

--- a/client/src/components/ui/AppBottomSheet.tsx
+++ b/client/src/components/ui/AppBottomSheet.tsx
@@ -134,7 +134,10 @@ export const AppBottomSheet = ({
     >
       <View
         className="px-4 pt-3"
-        style={contentHeight === undefined ? undefined : { height: contentHeight }}
+        style={[
+          contentHeight === undefined ? undefined : { height: contentHeight },
+          scrollable ? undefined : { paddingBottom: Math.max(insets.bottom, 12) },
+        ]}
       >
         <View className="mb-3 h-1 w-12 self-center rounded-full bg-muted-foreground/30" />
         {scrollable ? (

--- a/client/src/components/ui/NativeNoahIconButton.tsx
+++ b/client/src/components/ui/NativeNoahIconButton.tsx
@@ -17,7 +17,7 @@ import { NoahActivityIndicator } from "~/components/ui/NoahActivityIndicator";
 import { useTheme } from "~/hooks/useTheme";
 import { COLORS } from "~/lib/styleConstants";
 
-export type NativeNoahIcon = "back" | "board" | "history" | "refresh" | "share";
+export type NativeNoahIcon = "back" | "board" | "copy" | "history" | "more" | "refresh" | "share";
 
 const ICONS = {
   back: {
@@ -28,9 +28,17 @@ const ICONS = {
     ios: "ferry",
     android: "boat-outline",
   },
+  copy: {
+    ios: "doc.on.doc",
+    android: "copy-outline",
+  },
   history: {
     ios: "clock.arrow.circlepath",
     android: "time-outline",
+  },
+  more: {
+    ios: "ellipsis",
+    android: "ellipsis-horizontal",
   },
   refresh: {
     ios: "arrow.clockwise",

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -187,6 +187,34 @@ export function useGenerateOnchainAddress() {
   });
 }
 
+export function useGenerateReceiveAddresses() {
+  const { showAlert } = useAlert();
+
+  return useMutation({
+    mutationFn: async () => {
+      const [arkAddressResult, onchainAddressResult] = await Promise.all([
+        newAddress(),
+        onchainAddress(),
+      ]);
+
+      if (arkAddressResult.isErr()) {
+        throw arkAddressResult.error;
+      }
+      if (onchainAddressResult.isErr()) {
+        throw onchainAddressResult.error;
+      }
+
+      return {
+        arkAddress: arkAddressResult.value.address,
+        onchainAddress: onchainAddressResult.value,
+      };
+    },
+    onError: (error: Error) => {
+      showAlert({ title: "Receive Request Failed", description: error.message });
+    },
+  });
+}
+
 export function useGenerateLightningInvoice() {
   const { showAlert } = useAlert();
 

--- a/client/src/hooks/useReceiveRequest.ts
+++ b/client/src/hooks/useReceiveRequest.ts
@@ -1,0 +1,492 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useFocusEffect } from "@react-navigation/native";
+import type { Bolt11Invoice } from "react-native-nitro-ark";
+
+import { useAlert } from "~/contexts/AlertProvider";
+import {
+  isArkReceiveMovement,
+  isFailedOrCanceledMovement,
+  isLightningReceiveMovement,
+} from "~/lib/barkMovement";
+import logger from "~/lib/log";
+import {
+  subscribeArkoorAddressMovements,
+  subscribeLightningPaymentMovements,
+  type BarkNotificationEvent,
+  type BarkNotificationSubscription,
+} from "~/lib/paymentsApi";
+import { buildReceiveRequestUri } from "~/lib/receiveRequest";
+import { queryClient } from "~/queryClient";
+import { useGenerateLightningInvoice, useGenerateReceiveAddresses } from "~/hooks/usePayments";
+
+const SUBSCRIPTION_RETRY_DELAY_MS = 1000;
+const log = logger("useReceiveRequest");
+
+type ActiveReceiveSession = {
+  sessionId: number;
+  amountSat: number | null;
+  arkAddress?: string;
+  paymentHash?: string;
+};
+
+export type GeneratedReceiveRequest = {
+  amountSat: number | null;
+  arkAddress: string;
+  bip321Uri: string;
+  description: string;
+  lightningInvoice?: Bolt11Invoice;
+  onchainAddress: string;
+};
+
+type IdleDeadlineLike = {
+  readonly didTimeout: boolean;
+  timeRemaining: () => number;
+};
+
+type IdleCallbackLike = (deadline: IdleDeadlineLike) => void;
+
+type IdleTaskHandle =
+  | { kind: "idle"; id: number }
+  | { kind: "timeout"; id: ReturnType<typeof setTimeout> };
+
+const scheduleIdleTask = (callback: IdleCallbackLike): IdleTaskHandle => {
+  const requestIdleCallback = (
+    globalThis as typeof globalThis & {
+      requestIdleCallback?: (cb: IdleCallbackLike) => number;
+    }
+  ).requestIdleCallback;
+
+  if (requestIdleCallback) {
+    return { kind: "idle", id: requestIdleCallback(callback) };
+  }
+
+  return {
+    kind: "timeout",
+    id: setTimeout(() => {
+      callback({ didTimeout: false, timeRemaining: () => 0 });
+    }, 0),
+  };
+};
+
+const toError = (error: unknown) => (error instanceof Error ? error : new Error(String(error)));
+
+export function useReceiveRequest(onReceiveComplete: (amountSat: number) => void) {
+  const { showAlert } = useAlert();
+  const [request, setRequest] = useState<GeneratedReceiveRequest | null>(null);
+  const [baseError, setBaseError] = useState<Error | null>(null);
+  const [arkSubscriptionRetryTick, setArkSubscriptionRetryTick] = useState(0);
+  const [lightningSubscriptionRetryTick, setLightningSubscriptionRetryTick] = useState(0);
+  const receiveSessionIdRef = useRef(0);
+  const lightningGenerationIdRef = useRef(0);
+  const activeReceiveSessionRef = useRef<ActiveReceiveSession | null>(null);
+  const arkSubscriptionRef = useRef<BarkNotificationSubscription | null>(null);
+  const lightningSubscriptionRef = useRef<BarkNotificationSubscription | null>(null);
+  const arkSubscriptionRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lightningSubscriptionRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isCompletingReceiveRef = useRef(false);
+
+  const { mutateAsync: generateReceiveAddresses, isPending: isGeneratingBase } =
+    useGenerateReceiveAddresses();
+  const { mutateAsync: generateLightningInvoice, isPending: isGeneratingLightning } =
+    useGenerateLightningInvoice();
+
+  const stopSubscription = useCallback(
+    (subscription: BarkNotificationSubscription | null, label: string) => {
+      if (!subscription) {
+        return;
+      }
+
+      try {
+        subscription.stop();
+      } catch (error) {
+        log.w(`Failed to stop ${label} receive subscription`, [toError(error).message]);
+      }
+    },
+    [],
+  );
+
+  const releaseArkSubscription = useCallback(() => {
+    const subscription = arkSubscriptionRef.current;
+    arkSubscriptionRef.current = null;
+
+    if (subscription) {
+      scheduleIdleTask(() => stopSubscription(subscription, "Ark"));
+    }
+  }, [stopSubscription]);
+
+  const releaseLightningSubscription = useCallback(() => {
+    const subscription = lightningSubscriptionRef.current;
+    lightningSubscriptionRef.current = null;
+
+    if (subscription) {
+      scheduleIdleTask(() => stopSubscription(subscription, "Lightning"));
+    }
+  }, [stopSubscription]);
+
+  const clearArkSubscriptionRetry = useCallback(() => {
+    if (arkSubscriptionRetryTimeoutRef.current) {
+      clearTimeout(arkSubscriptionRetryTimeoutRef.current);
+      arkSubscriptionRetryTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearLightningSubscriptionRetry = useCallback(() => {
+    if (lightningSubscriptionRetryTimeoutRef.current) {
+      clearTimeout(lightningSubscriptionRetryTimeoutRef.current);
+      lightningSubscriptionRetryTimeoutRef.current = null;
+    }
+  }, []);
+
+  const cancelReceiveSession = useCallback(
+    ({ clearRequest }: { clearRequest: boolean }) => {
+      receiveSessionIdRef.current += 1;
+      lightningGenerationIdRef.current += 1;
+      activeReceiveSessionRef.current = null;
+      isCompletingReceiveRef.current = false;
+      clearArkSubscriptionRetry();
+      clearLightningSubscriptionRetry();
+      releaseArkSubscription();
+      releaseLightningSubscription();
+      if (clearRequest) {
+        setRequest(null);
+      }
+    },
+    [
+      clearArkSubscriptionRetry,
+      clearLightningSubscriptionRetry,
+      releaseArkSubscription,
+      releaseLightningSubscription,
+    ],
+  );
+
+  const handleReceiveComplete = useCallback(
+    (amountSat: number) => {
+      if (!activeReceiveSessionRef.current || isCompletingReceiveRef.current) {
+        return;
+      }
+
+      isCompletingReceiveRef.current = true;
+      cancelReceiveSession({ clearRequest: true });
+      void queryClient.invalidateQueries({ queryKey: ["balance"] });
+      void queryClient.invalidateQueries({ queryKey: ["transactions"] });
+      onReceiveComplete(amountSat);
+    },
+    [cancelReceiveSession, onReceiveComplete],
+  );
+
+  const handleArkoorReceiveEvent = useCallback(
+    (event: BarkNotificationEvent, sessionId: number) => {
+      if (event.kind === "channelLagging") {
+        return;
+      }
+
+      const activeSession = activeReceiveSessionRef.current;
+      const movement = event.movement;
+      if (
+        !activeSession ||
+        activeSession.sessionId !== sessionId ||
+        !movement ||
+        movement.status !== "successful" ||
+        !isArkReceiveMovement(movement)
+      ) {
+        return;
+      }
+
+      const matchingDestinations =
+        movement.received_on?.filter(
+          (destination) => destination.destination === activeSession.arkAddress,
+        ) ?? [];
+      if (matchingDestinations.length === 0) {
+        return;
+      }
+
+      const receivedAmountSat = matchingDestinations.reduce(
+        (total, destination) => total + destination.amount_sat,
+        0,
+      );
+      if (receivedAmountSat > 0) {
+        handleReceiveComplete(receivedAmountSat);
+      } else if (activeSession.amountSat !== null) {
+        handleReceiveComplete(activeSession.amountSat);
+      }
+    },
+    [handleReceiveComplete],
+  );
+
+  const handleLightningReceiveEvent = useCallback(
+    (event: BarkNotificationEvent, sessionId: number) => {
+      if (event.kind === "channelLagging") {
+        return;
+      }
+
+      const activeSession = activeReceiveSessionRef.current;
+      const movement = event.movement;
+      if (
+        !activeSession ||
+        activeSession.sessionId !== sessionId ||
+        !movement ||
+        !isLightningReceiveMovement(movement)
+      ) {
+        return;
+      }
+
+      if (isFailedOrCanceledMovement(movement)) {
+        const error = new Error(
+          "The Lightning payment could not be received. Generate a new payment request and try again.",
+        );
+        log.e("Lightning receive ended without completing", [
+          { movementId: movement.id, status: movement.status },
+        ]);
+        cancelReceiveSession({ clearRequest: true });
+        setBaseError(error);
+        void queryClient.invalidateQueries({ queryKey: ["balance"] });
+        void queryClient.invalidateQueries({ queryKey: ["transactions"] });
+        showAlert({
+          title:
+            movement.status === "canceled"
+              ? "Lightning Receive Canceled"
+              : "Lightning Receive Failed",
+          description: error.message,
+        });
+        return;
+      }
+
+      if (movement.status === "successful" && activeSession.amountSat !== null) {
+        handleReceiveComplete(activeSession.amountSat);
+      }
+    },
+    [cancelReceiveSession, handleReceiveComplete, showAlert],
+  );
+
+  const scheduleArkSubscriptionRetry = useCallback((sessionId: number) => {
+    if (arkSubscriptionRetryTimeoutRef.current) {
+      return;
+    }
+
+    arkSubscriptionRetryTimeoutRef.current = setTimeout(() => {
+      arkSubscriptionRetryTimeoutRef.current = null;
+      if (activeReceiveSessionRef.current?.sessionId === sessionId) {
+        setArkSubscriptionRetryTick((tick) => tick + 1);
+      }
+    }, SUBSCRIPTION_RETRY_DELAY_MS);
+  }, []);
+
+  const scheduleLightningSubscriptionRetry = useCallback((sessionId: number) => {
+    if (lightningSubscriptionRetryTimeoutRef.current) {
+      return;
+    }
+
+    lightningSubscriptionRetryTimeoutRef.current = setTimeout(() => {
+      lightningSubscriptionRetryTimeoutRef.current = null;
+      if (activeReceiveSessionRef.current?.sessionId === sessionId) {
+        setLightningSubscriptionRetryTick((tick) => tick + 1);
+      }
+    }, SUBSCRIPTION_RETRY_DELAY_MS);
+  }, []);
+
+  useEffect(() => {
+    const arkAddress = request?.arkAddress;
+    if (!arkAddress) {
+      return;
+    }
+
+    const activeSession = activeReceiveSessionRef.current;
+    if (!activeSession || activeSession.arkAddress === arkAddress) {
+      return;
+    }
+
+    releaseArkSubscription();
+    const subscriptionResult = subscribeArkoorAddressMovements(arkAddress, (event) => {
+      handleArkoorReceiveEvent(event, activeSession.sessionId);
+    });
+
+    if (subscriptionResult.isErr()) {
+      log.w("Failed to subscribe to Ark receive updates", [subscriptionResult.error.message]);
+      scheduleArkSubscriptionRetry(activeSession.sessionId);
+      return;
+    }
+
+    clearArkSubscriptionRetry();
+    activeSession.arkAddress = arkAddress;
+    arkSubscriptionRef.current = subscriptionResult.value;
+  }, [
+    arkSubscriptionRetryTick,
+    clearArkSubscriptionRetry,
+    handleArkoorReceiveEvent,
+    releaseArkSubscription,
+    request?.arkAddress,
+    scheduleArkSubscriptionRetry,
+  ]);
+
+  useEffect(() => {
+    const lightningInvoice = request?.lightningInvoice;
+    if (!lightningInvoice?.payment_hash) {
+      return;
+    }
+
+    const activeSession = activeReceiveSessionRef.current;
+    if (!activeSession || activeSession.paymentHash === lightningInvoice.payment_hash) {
+      return;
+    }
+
+    releaseLightningSubscription();
+    const subscriptionResult = subscribeLightningPaymentMovements(
+      lightningInvoice.payment_hash,
+      (event) => {
+        handleLightningReceiveEvent(event, activeSession.sessionId);
+      },
+    );
+
+    if (subscriptionResult.isErr()) {
+      log.w("Failed to subscribe to Lightning receive updates", [subscriptionResult.error.message]);
+      scheduleLightningSubscriptionRetry(activeSession.sessionId);
+      return;
+    }
+
+    clearLightningSubscriptionRetry();
+    activeSession.paymentHash = lightningInvoice.payment_hash;
+    lightningSubscriptionRef.current = subscriptionResult.value;
+  }, [
+    clearLightningSubscriptionRetry,
+    handleLightningReceiveEvent,
+    lightningSubscriptionRetryTick,
+    releaseLightningSubscription,
+    request?.lightningInvoice,
+    scheduleLightningSubscriptionRetry,
+  ]);
+
+  const generateBaseRequest = useCallback(async () => {
+    cancelReceiveSession({ clearRequest: true });
+    setBaseError(null);
+    const sessionId = receiveSessionIdRef.current;
+    activeReceiveSessionRef.current = { sessionId, amountSat: null };
+
+    let addresses: { arkAddress: string; onchainAddress: string };
+    try {
+      addresses = await generateReceiveAddresses();
+    } catch (error) {
+      if (activeReceiveSessionRef.current?.sessionId === sessionId) {
+        activeReceiveSessionRef.current = null;
+        setBaseError(toError(error));
+      }
+      return;
+    }
+
+    if (activeReceiveSessionRef.current?.sessionId !== sessionId) {
+      return;
+    }
+
+    try {
+      const bip321Uri = buildReceiveRequestUri({
+        amountSat: null,
+        arkAddress: addresses.arkAddress,
+        onchainAddress: addresses.onchainAddress,
+      });
+      setRequest({
+        ...addresses,
+        amountSat: null,
+        bip321Uri,
+        description: "",
+      });
+    } catch (error) {
+      const requestError = toError(error);
+      activeReceiveSessionRef.current = null;
+      setBaseError(requestError);
+      showAlert({ title: "Receive Request Failed", description: requestError.message });
+    }
+  }, [cancelReceiveSession, generateReceiveAddresses, showAlert]);
+
+  useFocusEffect(
+    useCallback(() => {
+      void generateBaseRequest();
+
+      return () => {
+        cancelReceiveSession({ clearRequest: true });
+        setBaseError(null);
+      };
+    }, [cancelReceiveSession, generateBaseRequest]),
+  );
+
+  const saveAmount = async ({
+    amountSat,
+    description,
+  }: {
+    amountSat: number;
+    description: string;
+  }) => {
+    const currentRequest = request;
+    const activeSession = activeReceiveSessionRef.current;
+    if (!currentRequest || !activeSession) {
+      throw new Error("A receive request must be ready before adding an amount");
+    }
+
+    const generationId = lightningGenerationIdRef.current + 1;
+    lightningGenerationIdRef.current = generationId;
+    const sessionId = activeSession.sessionId;
+    const lightningInvoice = await generateLightningInvoice({ amountSat, description });
+
+    if (
+      lightningGenerationIdRef.current !== generationId ||
+      activeReceiveSessionRef.current?.sessionId !== sessionId
+    ) {
+      return false;
+    }
+
+    try {
+      const bip321Uri = buildReceiveRequestUri({
+        amountSat,
+        arkAddress: currentRequest.arkAddress,
+        lightningInvoice: lightningInvoice.payment_request,
+        onchainAddress: currentRequest.onchainAddress,
+      });
+      activeReceiveSessionRef.current.amountSat = amountSat;
+      activeReceiveSessionRef.current.paymentHash = undefined;
+      setRequest({
+        ...currentRequest,
+        amountSat,
+        bip321Uri,
+        description,
+        lightningInvoice,
+      });
+      return true;
+    } catch (error) {
+      const requestError = toError(error);
+      showAlert({ title: "Receive Request Failed", description: requestError.message });
+      throw requestError;
+    }
+  };
+
+  const removeAmount = () => {
+    if (!request || !activeReceiveSessionRef.current) {
+      return;
+    }
+
+    lightningGenerationIdRef.current += 1;
+    clearLightningSubscriptionRetry();
+    releaseLightningSubscription();
+    activeReceiveSessionRef.current.amountSat = null;
+    activeReceiveSessionRef.current.paymentHash = undefined;
+    const bip321Uri = buildReceiveRequestUri({
+      amountSat: null,
+      arkAddress: request.arkAddress,
+      onchainAddress: request.onchainAddress,
+    });
+    setRequest({
+      amountSat: null,
+      arkAddress: request.arkAddress,
+      bip321Uri,
+      description: "",
+      onchainAddress: request.onchainAddress,
+    });
+  };
+
+  return {
+    baseError,
+    generateBaseRequest,
+    isGeneratingBase,
+    isGeneratingLightning,
+    removeAmount,
+    request,
+    saveAmount,
+  };
+}

--- a/client/src/hooks/useReceiveRequest.ts
+++ b/client/src/hooks/useReceiveRequest.ts
@@ -214,7 +214,7 @@ export function useReceiveRequest(onReceiveComplete: (amountSat: number) => void
   );
 
   const handleLightningReceiveEvent = useCallback(
-    (event: BarkNotificationEvent, sessionId: number) => {
+    (event: BarkNotificationEvent, sessionId: number, paymentHash: string) => {
       if (event.kind === "channelLagging") {
         return;
       }
@@ -224,6 +224,7 @@ export function useReceiveRequest(onReceiveComplete: (amountSat: number) => void
       if (
         !activeSession ||
         activeSession.sessionId !== sessionId ||
+        activeSession.paymentHash !== paymentHash ||
         !movement ||
         !isLightningReceiveMovement(movement)
       ) {
@@ -319,32 +320,35 @@ export function useReceiveRequest(onReceiveComplete: (amountSat: number) => void
   ]);
 
   useEffect(() => {
-    const lightningInvoice = request?.lightningInvoice;
-    if (!lightningInvoice?.payment_hash) {
+    const paymentHash = request?.lightningInvoice?.payment_hash;
+    if (!paymentHash) {
       return;
     }
 
     const activeSession = activeReceiveSessionRef.current;
-    if (!activeSession || activeSession.paymentHash === lightningInvoice.payment_hash) {
+    if (!activeSession || activeSession.paymentHash === paymentHash) {
       return;
     }
 
     releaseLightningSubscription();
-    const subscriptionResult = subscribeLightningPaymentMovements(
-      lightningInvoice.payment_hash,
-      (event) => {
-        handleLightningReceiveEvent(event, activeSession.sessionId);
-      },
-    );
+    activeSession.paymentHash = paymentHash;
+    const subscriptionResult = subscribeLightningPaymentMovements(paymentHash, (event) => {
+      handleLightningReceiveEvent(event, activeSession.sessionId, paymentHash);
+    });
 
     if (subscriptionResult.isErr()) {
+      if (
+        activeReceiveSessionRef.current?.sessionId === activeSession.sessionId &&
+        activeReceiveSessionRef.current.paymentHash === paymentHash
+      ) {
+        activeReceiveSessionRef.current.paymentHash = undefined;
+      }
       log.w("Failed to subscribe to Lightning receive updates", [subscriptionResult.error.message]);
       scheduleLightningSubscriptionRetry(activeSession.sessionId);
       return;
     }
 
     clearLightningSubscriptionRetry();
-    activeSession.paymentHash = lightningInvoice.payment_hash;
     lightningSubscriptionRef.current = subscriptionResult.value;
   }, [
     clearLightningSubscriptionRetry,

--- a/client/src/hooks/useReceiveScreen.ts
+++ b/client/src/hooks/useReceiveScreen.ts
@@ -46,6 +46,7 @@ export const useReceiveScreen = () => {
     amount,
     setAmount,
     currency,
+    setCurrency,
     toggleCurrency,
     amountSat,
     btcPrice,

--- a/client/src/hooks/useReceiveScreen.ts
+++ b/client/src/hooks/useReceiveScreen.ts
@@ -1,35 +1,25 @@
-import { useState, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useBtcToFiatRate } from "./useMarketData";
 import { fiatToSats, satsToFiat } from "~/lib/fiatCurrency";
 import { useProfileStore } from "~/store/profileStore";
 
 export const useReceiveScreen = () => {
-  const [amount, setAmount] = useState("");
+  const [amount, setAmountValue] = useState("");
+  const [canonicalAmountSat, setCanonicalAmountSat] = useState<number | null>(null);
   const [currency, setCurrency] = useState<"SATS" | "FIAT">("SATS");
   const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
   const { data: btcPrice } = useBtcToFiatRate();
 
-  const toggleCurrency = () => {
-    if (currency === "SATS") {
-      if (btcPrice && amount) {
-        const sats = parseInt(amount, 10);
-        if (!isNaN(sats)) {
-          setAmount(satsToFiat(sats, btcPrice, fiatCurrency));
-        }
-      }
-      setCurrency("FIAT");
-    } else {
-      if (btcPrice && amount) {
-        const fiatAmount = parseFloat(amount);
-        if (!isNaN(fiatAmount)) {
-          setAmount(fiatToSats(fiatAmount, btcPrice).toString());
-        }
-      }
-      setCurrency("SATS");
-    }
-  };
+  const setAmount = useCallback((value: string) => {
+    setAmountValue(value);
+    setCanonicalAmountSat(null);
+  }, []);
 
   const amountSat = useMemo(() => {
+    if (canonicalAmountSat !== null) {
+      return canonicalAmountSat;
+    }
+
     const amountFloat = parseFloat(amount);
     if (isNaN(amountFloat)) return 0;
 
@@ -40,7 +30,25 @@ export const useReceiveScreen = () => {
     if (!btcPrice) return 0;
 
     return fiatToSats(amountFloat, btcPrice);
-  }, [amount, currency, btcPrice, fiatCurrency]);
+  }, [amount, btcPrice, canonicalAmountSat, currency]);
+
+  const toggleCurrency = () => {
+    if (currency === "SATS") {
+      if (btcPrice && amount) {
+        if (amountSat > 0) {
+          setAmountValue(satsToFiat(amountSat, btcPrice, fiatCurrency));
+          setCanonicalAmountSat(amountSat);
+        }
+      }
+      setCurrency("FIAT");
+    } else {
+      if (amount) {
+        setAmountValue(amountSat.toString());
+        setCanonicalAmountSat(amountSat);
+      }
+      setCurrency("SATS");
+    }
+  };
 
   return {
     amount,

--- a/client/src/lib/receiveRequest.ts
+++ b/client/src/lib/receiveRequest.ts
@@ -1,0 +1,35 @@
+import { encodeBIP321 } from "bip-321";
+
+type AmountlessReceiveRequest = {
+  amountSat: null;
+  arkAddress: string;
+  lightningInvoice?: undefined;
+  onchainAddress: string;
+};
+
+type AmountfulReceiveRequest = {
+  amountSat: number;
+  arkAddress: string;
+  lightningInvoice: string;
+  onchainAddress: string;
+};
+
+export type ReceiveRequest = AmountlessReceiveRequest | AmountfulReceiveRequest;
+
+export const buildReceiveRequestUri = ({
+  amountSat,
+  arkAddress,
+  lightningInvoice,
+  onchainAddress,
+}: ReceiveRequest) => {
+  if (amountSat !== null && (!Number.isSafeInteger(amountSat) || amountSat <= 0)) {
+    throw new Error("Receive amount must be a positive whole number of sats");
+  }
+
+  return encodeBIP321({
+    address: onchainAddress,
+    amount: amountSat === null ? undefined : amountSat / 100_000_000,
+    ark: arkAddress,
+    lightning: lightningInvoice,
+  }).uri;
+};

--- a/client/src/screens/ReceiveScreen.tsx
+++ b/client/src/screens/ReceiveScreen.tsx
@@ -1,1007 +1,306 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  View,
-  Pressable,
-  TouchableWithoutFeedback,
-  Keyboard,
-  InteractionManager,
-  TextInput,
-  ScrollView,
-} from "react-native";
-import { Text } from "../components/ui/text";
-import { Button } from "~/components/ui/button";
-
-import {
-  useGenerateLightningInvoice,
-  useGenerateOnchainAddress,
-  useGenerateOffchainAddress,
-} from "../hooks/usePayments";
-import { useCopyToClipboard } from "../lib/clipboardUtils";
-import QRCode from "react-native-qrcode-svg";
-import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
-import { useFocusEffect, useNavigation } from "@react-navigation/native";
-import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import type { TabParamList } from "~/Navigators";
 import Icon from "@react-native-vector-icons/ionicons";
-import { useIconColor, useThemeColors } from "../hooks/useTheme";
-import { satsToBtc } from "~/lib/utils";
-import { formatFiatAmount, getFiatCurrencyInfo, satsToFiat } from "~/lib/fiatCurrency";
-import { useReceiveScreen } from "../hooks/useReceiveScreen";
-import { COLORS } from "~/lib/styleConstants";
-import { CurrencyToggle } from "~/components/CurrencyToggle";
-import {
-  subscribeArkoorAddressMovements,
-  subscribeLightningPaymentMovements,
-  type BarkNotificationEvent,
-  type BarkNotificationSubscription,
-} from "~/lib/paymentsApi";
-import {
-  isArkReceiveMovement,
-  isFailedOrCanceledMovement,
-  isLightningReceiveMovement,
-} from "~/lib/barkMovement";
-import logger from "~/lib/log";
-import type { Bolt11Invoice } from "react-native-nitro-ark";
-import { queryClient } from "~/queryClient";
-import { BlinkingCaret } from "~/components/BlinkingCaret";
-import { useBitcoinAmountFormatter, useBitcoinAmountUnit } from "~/hooks/useBitcoinAmountFormatter";
+import { useCallback, useState } from "react";
+import { Pressable, ScrollView, Share, useWindowDimensions, View } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import QRCode from "react-native-qrcode-svg";
+
+import logoImage from "../../assets/All_Files/light_dark_tinted/icon_clear_tinted_ios.png";
+import type { TabParamList } from "~/Navigators";
 import { BoardArkBottomSheet } from "~/components/BoardArkBottomSheet";
+import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
+import { ReceiveAmountBottomSheet } from "~/components/ReceiveAmountBottomSheet";
+import { ReceiveCopyBottomSheet } from "~/components/ReceiveCopyBottomSheet";
+import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
+import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
 import { NativeNoahIconButton } from "~/components/ui/NativeNoahIconButton";
-import {
-  getInvoiceDescriptionLength,
-  isInvoiceDescriptionValid,
-  MAX_INVOICE_DESCRIPTION_LENGTH,
-} from "~/lib/lightningInvoice";
-import { useAlert } from "~/contexts/AlertProvider";
+import { NativeNoahSecondaryButton } from "~/components/ui/NativeNoahSecondaryButton";
+import { NoahActivityIndicator } from "~/components/ui/NoahActivityIndicator";
+import { Text } from "~/components/ui/text";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
+import { useBtcToFiatRate } from "~/hooks/useMarketData";
+import { useReceiveRequest } from "~/hooks/useReceiveRequest";
+import { useThemeColors } from "~/hooks/useTheme";
+import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
+import logger from "~/lib/log";
+import { COLORS } from "~/lib/styleConstants";
+import { useProfileStore } from "~/store/profileStore";
 
-const minAmount = 1;
-const SUBSCRIPTION_RETRY_DELAY_MS = 1000;
 const log = logger("ReceiveScreen");
-
-type ActiveReceiveSession = {
-  sessionId: number;
-  amountSat: number | null;
-  paymentHash?: string;
-  arkAddress?: string;
-};
-
-type ReceiveRailGeneration = {
-  arkAddress?: string;
-  lightningInvoice?: Bolt11Invoice;
-  onchainAddress?: string;
-};
-
-type GeneratedReceiveRequest = ReceiveRailGeneration & {
-  amountSat: number | null;
-};
-
-type IdleDeadlineLike = {
-  readonly didTimeout: boolean;
-  timeRemaining: () => number;
-};
-
-type IdleCallbackLike = (deadline: IdleDeadlineLike) => void;
-
-type IdleTaskHandle =
-  | { kind: "idle"; id: number }
-  | { kind: "timeout"; id: ReturnType<typeof setTimeout> };
-
-const scheduleIdleTask = (callback: IdleCallbackLike): IdleTaskHandle => {
-  const requestIdleCallback = (
-    globalThis as typeof globalThis & {
-      requestIdleCallback?: (cb: IdleCallbackLike) => number;
-    }
-  ).requestIdleCallback;
-
-  if (requestIdleCallback) {
-    return { kind: "idle", id: requestIdleCallback(callback) };
-  }
-
-  return {
-    kind: "timeout",
-    id: setTimeout(() => {
-      callback({
-        didTimeout: false,
-        timeRemaining: () => 0,
-      });
-    }, 0),
-  };
-};
-
-const truncateAddress = (addr: string) => {
-  if (addr.length <= 40) {
-    return addr;
-  }
-  return `${addr.slice(0, 15)}...${addr.slice(-15)}`;
-};
-
-const buildReceiveRequestUri = ({
-  amountSat,
-  arkAddress,
-  lightningInvoice,
-  onchainAddress,
-}: ReceiveRailGeneration & { amountSat: number | null }) => {
-  const params: string[] = [];
-
-  if (amountSat !== null && amountSat >= minAmount) {
-    params.push(`amount=${satsToBtc(amountSat)}`);
-  }
-
-  if (arkAddress) {
-    params.push(`ark=${arkAddress.toUpperCase()}`);
-  }
-
-  if (amountSat !== null && amountSat >= minAmount && lightningInvoice?.payment_request) {
-    params.push(`lightning=${lightningInvoice.payment_request.toUpperCase()}`);
-  }
-
-  if (!onchainAddress && params.length === 0) {
-    return undefined;
-  }
-
-  let uri = `bitcoin:${onchainAddress ?? ""}`;
-
-  if (params.length > 0) {
-    uri += `?${params.join("&")}`;
-  }
-
-  return uri;
-};
-
-const PaymentRail = ({
-  icon,
-  label,
-  value,
-  onCopy,
-  isCopied,
-  actionLabel,
-}: {
-  icon: React.ComponentProps<typeof Icon>["name"];
-  label: string;
-  value: string;
-  onCopy?: () => void;
-  isCopied: boolean;
-  actionLabel?: string;
-}) => {
-  const iconColor = useIconColor();
-  const isCopyable = Boolean(onCopy);
-
-  return (
-    <Pressable onPress={onCopy} disabled={!isCopyable} className="flex-row items-center gap-4 py-4">
-      <View
-        className="h-11 w-11 items-center justify-center rounded-full border border-border"
-        style={{ backgroundColor: "rgba(201, 138, 60, 0.10)" }}
-      >
-        <Icon name={icon} size={18} color={iconColor} />
-      </View>
-      <View className="flex-1">
-        <Text className="text-sm font-semibold text-foreground">{label}</Text>
-        <Text
-          className="mt-1 text-sm text-muted-foreground"
-          ellipsizeMode={isCopyable ? "middle" : "tail"}
-          numberOfLines={isCopyable ? 1 : 2}
-        >
-          {truncateAddress(value)}
-        </Text>
-      </View>
-      <Text
-        className="text-xs font-semibold uppercase tracking-[2px]"
-        style={{
-          color: isCopied
-            ? COLORS.SUCCESS
-            : isCopyable
-              ? COLORS.BITCOIN_ORANGE
-              : COLORS.TAB_BAR_INACTIVE,
-        }}
-      >
-        {isCopied ? "Copied" : (actionLabel ?? (isCopyable ? "Copy" : ""))}
-      </Text>
-    </Pressable>
-  );
-};
+const DESTRUCTIVE_COLOR = "#dc2626";
 
 const ReceiveScreen = () => {
   const navigation = useNavigation<NativeStackNavigationProp<TabParamList>>();
-  const { showAlert } = useAlert();
   const colors = useThemeColors();
+  const { width } = useWindowDimensions();
+  const fiatCurrency = useProfileStore((state) => state.preferredCurrency);
   const formatBitcoinAmount = useBitcoinAmountFormatter();
-  const bitcoinAmountUnit = useBitcoinAmountUnit();
-  const { amount, setAmount, currency, toggleCurrency, amountSat, btcPrice, fiatCurrency } =
-    useReceiveScreen();
-  const fiatCurrencyInfo = getFiatCurrencyInfo(fiatCurrency);
-  const { copyWithState, isCopied } = useCopyToClipboard();
-  const [generatedRequest, setGeneratedRequest] = useState<GeneratedReceiveRequest | null>(null);
-  const [description, setDescription] = useState("");
-  const receiveSessionIdRef = useRef(0);
-  const activeReceiveSessionRef = useRef<ActiveReceiveSession | null>(null);
-  const arkSubscriptionRef = useRef<BarkNotificationSubscription | null>(null);
-  const lightningSubscriptionRef = useRef<BarkNotificationSubscription | null>(null);
-  const arkSubscriptionRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const lightningSubscriptionRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingReceiveGenerationTaskRef = useRef<ReturnType<
-    typeof InteractionManager.runAfterInteractions
-  > | null>(null);
-  const receiveGenerationRequestIdRef = useRef(0);
-  const isCompletingReceiveRef = useRef(false);
-  const amountInputRef = useRef<TextInput>(null);
-  const [isSchedulingGeneration, setIsSchedulingGeneration] = useState(false);
-  const [arkSubscriptionRetryTick, setArkSubscriptionRetryTick] = useState(0);
-  const [lightningSubscriptionRetryTick, setLightningSubscriptionRetryTick] = useState(0);
+  const { data: btcPrice } = useBtcToFiatRate();
+  const [isAmountSheetOpen, setIsAmountSheetOpen] = useState(false);
+  const [isCopySheetOpen, setIsCopySheetOpen] = useState(false);
+  const [isActionsSheetOpen, setIsActionsSheetOpen] = useState(false);
+  const [shouldOpenBoardArkSheet, setShouldOpenBoardArkSheet] = useState(false);
   const [isBoardArkSheetOpen, setIsBoardArkSheetOpen] = useState(false);
 
-  const { mutateAsync: generateOffchainAddress, isPending: isGeneratingVtxo } =
-    useGenerateOffchainAddress();
-
-  const { mutateAsync: generateOnchainAddress, isPending: isGeneratingOnchain } =
-    useGenerateOnchainAddress();
-
-  const { mutateAsync: generateLightningInvoice, isPending: isGeneratingLightning } =
-    useGenerateLightningInvoice();
-
-  const isLoading =
-    isSchedulingGeneration || isGeneratingVtxo || isGeneratingOnchain || isGeneratingLightning;
-  const generatedAmountSat = generatedRequest?.amountSat ?? null;
-  const arkAddress = generatedRequest?.arkAddress;
-  const generatedOnchainAddress = generatedRequest?.onchainAddress;
-  const lightningInvoice = generatedRequest?.lightningInvoice;
-  const bip321Uri = useMemo(
-    () =>
-      buildReceiveRequestUri({
-        amountSat: generatedAmountSat,
-        arkAddress,
-        lightningInvoice,
-        onchainAddress: generatedOnchainAddress,
-      }),
-    [arkAddress, generatedAmountSat, generatedOnchainAddress, lightningInvoice],
-  );
-  const isGenerated = Boolean(bip321Uri);
-  const isClearDisabled = isLoading || (!isGenerated && amount === "" && description === "");
-  const isAmountLocked = isLoading || isGenerated;
-  const hasEnteredAmount = amount.trim().length > 0;
-  const canGenerateLightningInvoice = hasEnteredAmount && amountSat >= minAmount;
-  const descriptionLength = getInvoiceDescriptionLength(description);
-  const isDescriptionTooLong = !isInvoiceDescriptionValid(description);
-  const isAmountlessLightningRequest = isGenerated && generatedAmountSat === null;
-  const displayAmount = amount === "" ? (currency === "FIAT" ? "0.00" : "0") : amount;
-  const amountPrefix =
-    currency === "FIAT" ? fiatCurrencyInfo.symbol : bitcoinAmountUnit === "bip177" ? "₿" : null;
-  const amountSuffix = currency === "SATS" && bitcoinAmountUnit === "sats" ? "sats" : null;
-  const [isAmountFocused, setIsAmountFocused] = useState(false);
-
-  const stopSubscription = useCallback(
-    (subscription: BarkNotificationSubscription | null, label: string) => {
-      if (!subscription) {
-        return;
-      }
-
-      try {
-        subscription.stop();
-      } catch (error) {
-        log.w(`Failed to stop ${label} receive subscription`, [
-          error instanceof Error ? error.message : String(error),
-        ]);
-      }
-    },
-    [],
-  );
-
-  const releaseArkSubscription = useCallback(() => {
-    const subscription = arkSubscriptionRef.current;
-    arkSubscriptionRef.current = null;
-
-    if (!subscription) {
-      return;
-    }
-
-    scheduleIdleTask(() => {
-      stopSubscription(subscription, "Ark");
-    });
-  }, [stopSubscription]);
-
-  const releaseLightningSubscription = useCallback(() => {
-    const subscription = lightningSubscriptionRef.current;
-    lightningSubscriptionRef.current = null;
-
-    if (!subscription) {
-      return;
-    }
-
-    scheduleIdleTask(() => {
-      stopSubscription(subscription, "Lightning");
-    });
-  }, [stopSubscription]);
-
-  const clearArkSubscriptionRetry = useCallback(() => {
-    if (!arkSubscriptionRetryTimeoutRef.current) {
-      return;
-    }
-
-    clearTimeout(arkSubscriptionRetryTimeoutRef.current);
-    arkSubscriptionRetryTimeoutRef.current = null;
-  }, []);
-
-  const clearLightningSubscriptionRetry = useCallback(() => {
-    if (!lightningSubscriptionRetryTimeoutRef.current) {
-      return;
-    }
-
-    clearTimeout(lightningSubscriptionRetryTimeoutRef.current);
-    lightningSubscriptionRetryTimeoutRef.current = null;
-  }, []);
-
-  const cancelPendingReceiveGeneration = useCallback(() => {
-    receiveGenerationRequestIdRef.current += 1;
-    pendingReceiveGenerationTaskRef.current?.cancel();
-    pendingReceiveGenerationTaskRef.current = null;
-    setIsSchedulingGeneration(false);
-  }, []);
-
-  const scheduleArkSubscriptionRetry = useCallback((sessionId: number) => {
-    if (arkSubscriptionRetryTimeoutRef.current) {
-      return;
-    }
-
-    arkSubscriptionRetryTimeoutRef.current = setTimeout(() => {
-      arkSubscriptionRetryTimeoutRef.current = null;
-
-      if (activeReceiveSessionRef.current?.sessionId !== sessionId) {
-        return;
-      }
-
-      setArkSubscriptionRetryTick((tick) => tick + 1);
-    }, SUBSCRIPTION_RETRY_DELAY_MS);
-  }, []);
-
-  const scheduleLightningSubscriptionRetry = useCallback((sessionId: number) => {
-    if (lightningSubscriptionRetryTimeoutRef.current) {
-      return;
-    }
-
-    lightningSubscriptionRetryTimeoutRef.current = setTimeout(() => {
-      lightningSubscriptionRetryTimeoutRef.current = null;
-
-      if (activeReceiveSessionRef.current?.sessionId !== sessionId) {
-        return;
-      }
-
-      setLightningSubscriptionRetryTick((tick) => tick + 1);
-    }, SUBSCRIPTION_RETRY_DELAY_MS);
-  }, []);
-
-  const clearGeneratedReceiveData = useCallback(
-    ({ resetAmount }: { resetAmount: boolean }) => {
-      setGeneratedRequest(null);
-      if (resetAmount) {
-        setAmount("");
-        setDescription("");
-      }
-    },
-    [setAmount],
-  );
-
-  const cancelReceiveSession = useCallback(
-    ({ resetAmount }: { resetAmount: boolean }) => {
-      receiveSessionIdRef.current += 1;
-      cancelPendingReceiveGeneration();
-      activeReceiveSessionRef.current = null;
-      isCompletingReceiveRef.current = false;
-      clearArkSubscriptionRetry();
-      clearLightningSubscriptionRetry();
-      clearGeneratedReceiveData({ resetAmount });
-      releaseArkSubscription();
-      releaseLightningSubscription();
-    },
-    [
-      clearArkSubscriptionRetry,
-      clearGeneratedReceiveData,
-      clearLightningSubscriptionRetry,
-      cancelPendingReceiveGeneration,
-      releaseArkSubscription,
-      releaseLightningSubscription,
-    ],
-  );
-
   const handleReceiveComplete = useCallback(
-    (receivedAmountSat: number) => {
-      if (!activeReceiveSessionRef.current || isCompletingReceiveRef.current) {
-        return;
-      }
-
-      isCompletingReceiveRef.current = true;
-      cancelReceiveSession({ resetAmount: true });
-      void queryClient.invalidateQueries({ queryKey: ["balance"] });
-      void queryClient.invalidateQueries({ queryKey: ["transactions"] });
-
+    (amountSat: number) => {
       navigation.navigate("Home", {
         screen: "ReceiveSuccess",
-        params: { amountSat: receivedAmountSat },
+        params: { amountSat },
       });
     },
-    [cancelReceiveSession, navigation],
+    [navigation],
   );
 
-  const handleArkoorReceiveEvent = useCallback(
-    (event: BarkNotificationEvent, sessionId: number) => {
-      if (event.kind === "channelLagging") {
-        return;
-      }
+  const {
+    baseError,
+    generateBaseRequest,
+    isGeneratingBase,
+    isGeneratingLightning,
+    removeAmount,
+    request,
+    saveAmount,
+  } = useReceiveRequest(handleReceiveComplete);
 
-      const activeSession = activeReceiveSessionRef.current;
-      if (!activeSession || activeSession.sessionId !== sessionId) {
-        return;
-      }
+  const qrSize = Math.min(270, width - 72);
+  const formattedFiatAmount =
+    request?.amountSat && btcPrice
+      ? formatFiatAmount(satsToFiat(request.amountSat, btcPrice, fiatCurrency), fiatCurrency)
+      : null;
 
-      const movement = event.movement;
-      if (!movement || movement.status !== "successful" || !isArkReceiveMovement(movement)) {
-        return;
-      }
-
-      const matchingReceivedOn =
-        movement.received_on?.filter(
-          (destination) => destination.destination === activeSession.arkAddress,
-        ) ?? [];
-
-      if (matchingReceivedOn.length === 0) {
-        return;
-      }
-
-      const receivedAmountSat = matchingReceivedOn.reduce(
-        (sum, destination) => sum + destination.amount_sat,
-        0,
-      );
-
-      if (receivedAmountSat > 0) {
-        handleReceiveComplete(receivedAmountSat);
-      } else if (activeSession.amountSat !== null) {
-        handleReceiveComplete(activeSession.amountSat);
-      }
-    },
-    [handleReceiveComplete],
-  );
-
-  const handleLightningReceiveEvent = useCallback(
-    (event: BarkNotificationEvent, sessionId: number) => {
-      if (event.kind === "channelLagging") {
-        return;
-      }
-
-      const activeSession = activeReceiveSessionRef.current;
-      if (!activeSession || activeSession.sessionId !== sessionId) {
-        return;
-      }
-
-      const movement = event.movement;
-      if (!movement || !isLightningReceiveMovement(movement)) {
-        return;
-      }
-
-      if (isFailedOrCanceledMovement(movement)) {
-        log.e("Lightning receive ended without completing", [
-          { movementId: movement.id, status: movement.status },
-        ]);
-        cancelReceiveSession({ resetAmount: false });
-        void queryClient.invalidateQueries({ queryKey: ["balance"] });
-        void queryClient.invalidateQueries({ queryKey: ["transactions"] });
-        showAlert({
-          title:
-            movement.status === "canceled"
-              ? "Lightning Receive Canceled"
-              : "Lightning Receive Failed",
-          description:
-            "The Lightning payment could not be received. Generate a new payment request and try again.",
-        });
-        return;
-      }
-
-      if (movement.status !== "successful") {
-        return;
-      }
-
-      if (activeSession.amountSat === null) {
-        return;
-      }
-
-      handleReceiveComplete(activeSession.amountSat);
-    },
-    [cancelReceiveSession, handleReceiveComplete, showAlert],
-  );
-
-  useEffect(() => {
-    if (!lightningInvoice?.payment_hash) {
+  const shareRequest = () => {
+    if (!request) {
       return;
     }
 
-    const activeSession = activeReceiveSessionRef.current;
-    if (!activeSession || activeSession.paymentHash === lightningInvoice.payment_hash) {
-      return;
-    }
-
-    releaseLightningSubscription();
-
-    const subscriptionResult = subscribeLightningPaymentMovements(
-      lightningInvoice.payment_hash,
-      (event) => {
-        handleLightningReceiveEvent(event, activeSession.sessionId);
-      },
-    );
-
-    if (subscriptionResult.isErr()) {
-      log.w("Failed to subscribe to Lightning receive updates", [subscriptionResult.error.message]);
-      scheduleLightningSubscriptionRetry(activeSession.sessionId);
-      return;
-    }
-
-    clearLightningSubscriptionRetry();
-    activeSession.paymentHash = lightningInvoice.payment_hash;
-    lightningSubscriptionRef.current = subscriptionResult.value;
-  }, [
-    clearLightningSubscriptionRetry,
-    handleLightningReceiveEvent,
-    lightningInvoice?.payment_hash,
-    releaseLightningSubscription,
-    lightningSubscriptionRetryTick,
-    scheduleLightningSubscriptionRetry,
-  ]);
-
-  useEffect(() => {
-    if (!arkAddress) {
-      return;
-    }
-
-    const activeSession = activeReceiveSessionRef.current;
-    if (!activeSession || activeSession.arkAddress === arkAddress) {
-      return;
-    }
-
-    releaseArkSubscription();
-
-    const subscriptionResult = subscribeArkoorAddressMovements(arkAddress, (event) => {
-      handleArkoorReceiveEvent(event, activeSession.sessionId);
-    });
-
-    if (subscriptionResult.isErr()) {
-      log.w("Failed to subscribe to Ark receive updates", [subscriptionResult.error.message]);
-      scheduleArkSubscriptionRetry(activeSession.sessionId);
-      return;
-    }
-
-    clearArkSubscriptionRetry();
-    activeSession.arkAddress = arkAddress;
-    arkSubscriptionRef.current = subscriptionResult.value;
-  }, [
-    arkAddress,
-    arkSubscriptionRetryTick,
-    clearArkSubscriptionRetry,
-    handleArkoorReceiveEvent,
-    releaseArkSubscription,
-    scheduleArkSubscriptionRetry,
-  ]);
-
-  useFocusEffect(
-    useCallback(() => {
-      return () => {
-        cancelReceiveSession({ resetAmount: false });
-      };
-    }, [cancelReceiveSession]),
-  );
-
-  const generateReceiveRequest = useCallback(() => {
-    const requestAmountSat = canGenerateLightningInvoice ? amountSat : null;
-
-    cancelReceiveSession({ resetAmount: false });
-    setGeneratedRequest({ amountSat: requestAmountSat });
-    activeReceiveSessionRef.current = {
-      sessionId: receiveSessionIdRef.current,
-      amountSat: requestAmountSat,
-    };
-
-    const sessionId = receiveSessionIdRef.current;
-    const lightningInvoiceTask =
-      requestAmountSat === null
-        ? Promise.resolve<Bolt11Invoice | undefined>(undefined)
-        : generateLightningInvoice({ amountSat: requestAmountSat, description });
-
-    const generationTasks = [
-      generateOnchainAddress(),
-      generateOffchainAddress(),
-      lightningInvoiceTask,
-    ] as const;
-
-    void Promise.allSettled(generationTasks).then(
-      ([nextOnchainAddressResult, nextArkAddressResult, nextLightningInvoiceResult]) => {
-        if (activeReceiveSessionRef.current?.sessionId !== sessionId) {
-          return;
-        }
-
-        if (nextOnchainAddressResult.status === "rejected") {
-          log.w("Receive rail generation failed", ["onchain", nextOnchainAddressResult.reason]);
-        }
-
-        if (nextArkAddressResult.status === "rejected") {
-          log.w("Receive rail generation failed", ["ark", nextArkAddressResult.reason]);
-        }
-
-        if (nextLightningInvoiceResult.status === "rejected") {
-          log.w("Receive rail generation failed", ["lightning", nextLightningInvoiceResult.reason]);
-        }
-
-        const nextOnchainAddress =
-          nextOnchainAddressResult.status === "fulfilled"
-            ? nextOnchainAddressResult.value
-            : undefined;
-        const nextArkAddress =
-          nextArkAddressResult.status === "fulfilled" ? nextArkAddressResult.value : undefined;
-        const nextLightningInvoice =
-          nextLightningInvoiceResult.status === "fulfilled"
-            ? nextLightningInvoiceResult.value
-            : undefined;
-
-        if (!nextOnchainAddress && !nextArkAddress && !nextLightningInvoice) {
-          cancelReceiveSession({ resetAmount: false });
-          return;
-        }
-
-        setGeneratedRequest({
-          amountSat: requestAmountSat,
-          onchainAddress: nextOnchainAddress,
-          arkAddress: nextArkAddress,
-          lightningInvoice: nextLightningInvoice,
-        });
-      },
-    );
-  }, [
-    amountSat,
-    cancelReceiveSession,
-    canGenerateLightningInvoice,
-    description,
-    generateLightningInvoice,
-    generateOffchainAddress,
-    generateOnchainAddress,
-  ]);
-
-  const handleGenerate = () => {
-    if (isDescriptionTooLong) {
-      return;
-    }
-
-    Keyboard.dismiss();
-    cancelPendingReceiveGeneration();
-
-    const requestId = receiveGenerationRequestIdRef.current + 1;
-    receiveGenerationRequestIdRef.current = requestId;
-    setIsSchedulingGeneration(true);
-
-    pendingReceiveGenerationTaskRef.current = InteractionManager.runAfterInteractions(() => {
-      if (receiveGenerationRequestIdRef.current !== requestId) {
-        return;
-      }
-
-      pendingReceiveGenerationTaskRef.current = null;
-      setIsSchedulingGeneration(false);
-      generateReceiveRequest();
+    void Share.share({ message: request.bip321Uri }).catch((error) => {
+      log.w("Could not share receive request", [
+        error instanceof Error ? error.message : String(error),
+      ]);
     });
   };
 
-  const handleClear = () => {
-    cancelReceiveSession({ resetAmount: true });
+  const submitAmount = async (nextAmount: { amountSat: number; description: string }) => {
+    try {
+      const didSave = await saveAmount(nextAmount);
+      if (didSave) {
+        setIsAmountSheetOpen(false);
+      }
+    } catch (error) {
+      log.w("Could not add an amount to the receive request", [
+        error instanceof Error ? error.message : String(error),
+      ]);
+    }
   };
 
-  const handleCopyToClipboard = (value: string, type: string) => {
-    copyWithState(value, type);
+  const removeRequestAmount = () => {
+    removeAmount();
+    setIsAmountSheetOpen(false);
   };
 
-  const focusAmountInput = useCallback(() => {
-    if (isAmountLocked) {
-      return;
-    }
-
-    requestAnimationFrame(() => {
-      amountInputRef.current?.focus();
-    });
-  }, [isAmountLocked]);
-
-  useEffect(() => {
-    if (!isAmountLocked) {
-      return;
-    }
-
-    amountInputRef.current?.blur();
-    setIsAmountFocused(false);
-  }, [isAmountLocked]);
+  const openBoardToArk = () => {
+    setShouldOpenBoardArkSheet(true);
+    setIsActionsSheetOpen(false);
+  };
 
   return (
     <NoahSafeAreaView className="flex-1 bg-background">
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <ScrollView
-          className="flex-1"
-          showsVerticalScrollIndicator={false}
-          keyboardShouldPersistTaps="handled"
-          contentContainerStyle={{ paddingBottom: 32 }}
-        >
-          <View className="px-5 pb-8">
-            <View className="mb-4 flex-row items-center justify-between pt-1">
-              <Text className="text-2xl font-bold text-foreground">Receive</Text>
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ flexGrow: 1, paddingBottom: 32 }}
+        showsVerticalScrollIndicator={false}
+      >
+        <View className="flex-1 px-5 pb-8">
+          <View className="flex-row items-center justify-between pt-1">
+            <Text className="text-2xl font-bold text-foreground">Receive</Text>
+            <View className="flex-row items-center gap-2">
               <NativeNoahIconButton
-                icon="board"
-                accessibilityLabel="Board to Ark"
-                onPress={() => {
-                  Keyboard.dismiss();
-                  setIsBoardArkSheetOpen(true);
-                }}
-                size={52}
-                iconSize={23}
-                testID="receive-board-ark-button"
+                icon="copy"
+                accessibilityLabel="Show payment details"
+                onPress={() => setIsCopySheetOpen(true)}
+                disabled={!request}
+                testID="receive-copy-button"
+              />
+              <NativeNoahIconButton
+                icon="more"
+                accessibilityLabel="More receive actions"
+                onPress={() => setIsActionsSheetOpen(true)}
+                testID="receive-more-button"
               />
             </View>
+          </View>
 
-            <View className="pt-1">
-              <Text className="text-[11px] font-semibold uppercase tracking-[3px] text-muted-foreground">
-                Receive Bitcoin
-              </Text>
-              <Text className="mt-2 max-w-[320px] text-base leading-6 text-muted-foreground">
-                Generate a payment request with Ark, Lightning, and on-chain rails when available.
-              </Text>
-            </View>
+          <View className="flex-1 items-center justify-center py-8">
+            {request ? (
+              <>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Show payment details"
+                  accessibilityHint="Opens options to copy the unified request or an individual payment method"
+                  onPress={() => setIsCopySheetOpen(true)}
+                  className="items-center"
+                  testID="receive-qr-button"
+                >
+                  <View className="overflow-hidden rounded-[28px] bg-white shadow-sm shadow-foreground/5">
+                    <View className="p-4">
+                      <QRCode
+                        value={request.bip321Uri}
+                        size={qrSize}
+                        backgroundColor="white"
+                        color="black"
+                        logo={logoImage}
+                        logoSize={44}
+                        logoBackgroundColor="white"
+                        logoMargin={4}
+                        logoBorderRadius={11}
+                        ecl="H"
+                      />
+                    </View>
 
-            <View className="mt-4">
-              <View className="flex-row items-start justify-end gap-4">
-                <View className="flex-1">
-                  {isGenerated ? (
-                    <Text className="text-sm text-muted-foreground">
-                      Listening for payment until you clear or leave this screen.
-                    </Text>
-                  ) : null}
-                </View>
-                <CurrencyToggle onPress={toggleCurrency} disabled={isAmountLocked} />
-              </View>
-
-              <View className="mt-4 items-center">
-                <View className="mt-2 h-[64px] justify-center">
-                  <View className="self-center">
-                    <Pressable onPress={focusAmountInput} disabled={isAmountLocked}>
-                      <View className="flex-row items-center justify-center">
-                        {amountPrefix ? (
-                          <Text className="mr-3 text-[46px] font-bold leading-[52px] text-foreground">
-                            {amountPrefix}
-                          </Text>
-                        ) : null}
-                        <Text className="text-[46px] font-bold leading-[52px] text-foreground">
-                          {displayAmount}
+                    {request.amountSat !== null ? (
+                      <View
+                        className="items-center px-5 py-5"
+                        style={{ backgroundColor: COLORS.BITCOIN_ORANGE }}
+                      >
+                        <Text className="text-[38px] font-bold leading-[44px] text-[#1a1a1a]">
+                          {formatBitcoinAmount(request.amountSat)}
                         </Text>
-                        <BlinkingCaret
-                          color={COLORS.BITCOIN_ORANGE}
-                          height={40}
-                          visible={isAmountFocused && !isAmountLocked}
-                        />
-                        {amountSuffix ? (
-                          <Text className="ml-3 text-2xl font-bold text-muted-foreground">
-                            {amountSuffix}
+                        {formattedFiatAmount ? (
+                          <Text className="mt-1 text-base font-semibold text-[#1a1a1a]/75">
+                            {formattedFiatAmount}
                           </Text>
                         ) : null}
                       </View>
-                    </Pressable>
+                    ) : null}
                   </View>
+                </Pressable>
 
-                  <TextInput
-                    ref={amountInputRef}
-                    placeholder=""
-                    keyboardType="numeric"
-                    value={amount}
-                    onChangeText={setAmount}
-                    autoFocus={false}
-                    editable={!isAmountLocked}
-                    onFocus={() => setIsAmountFocused(true)}
-                    onBlur={() => setIsAmountFocused(false)}
-                    maxLength={12}
-                    selectionColor={COLORS.BITCOIN_ORANGE}
-                    style={{
-                      position: "absolute",
-                      opacity: 0,
-                      width: 1,
-                      height: 1,
-                    }}
-                  />
-                </View>
-
-                <Text className="mt-3 text-lg font-medium text-muted-foreground">
-                  {currency === "SATS"
-                    ? `≈ ${
-                        btcPrice && amountSat && !isNaN(amountSat)
-                          ? formatFiatAmount(
-                              satsToFiat(amountSat, btcPrice, fiatCurrency),
-                              fiatCurrency,
-                            )
-                          : formatFiatAmount("0.00", fiatCurrency)
-                      }`
-                    : `≈ ${!isNaN(amountSat) && amount ? formatBitcoinAmount(amountSat) : formatBitcoinAmount(0)}`}
+                <Text className="mt-6 text-center text-base font-medium text-foreground">
+                  Scan to receive bitcoin with Noah
                 </Text>
-
-                <View
-                  className="mt-5 w-full rounded-[22px] border px-4 py-3"
-                  style={{
-                    borderColor: `${colors.mutedForeground}26`,
-                    backgroundColor: `${colors.card}CC`,
-                  }}
-                >
-                  <TextInput
-                    className="min-h-9 text-base text-foreground"
-                    placeholder="Description (optional)"
-                    placeholderTextColor={colors.mutedForeground}
-                    value={description}
-                    onChangeText={setDescription}
-                    editable={!isAmountLocked}
-                    returnKeyType="done"
-                    onSubmitEditing={Keyboard.dismiss}
-                  />
-                </View>
-                {isDescriptionTooLong ? (
-                  <Text className="mt-2 text-sm text-destructive">
-                    Description is {descriptionLength} characters; maximum is{" "}
-                    {MAX_INVOICE_DESCRIPTION_LENGTH}.
-                  </Text>
-                ) : null}
-
-                {isGenerated ? (
-                  <View
-                    className="mt-4 rounded-full border px-4 py-2"
-                    style={{
-                      borderColor: `${colors.mutedForeground}1F`,
-                    }}
-                  >
-                    <Text className="text-sm text-muted-foreground">Payment request is live</Text>
+                {request.amountSat === null ? (
+                  <View className="mt-3 flex-row items-center gap-2">
+                    <Icon name="flash-outline" size={17} color={COLORS.BITCOIN_ORANGE} />
+                    <Text className="text-center text-sm text-muted-foreground">
+                      Add an amount to receive over Lightning
+                    </Text>
                   </View>
                 ) : null}
+              </>
+            ) : isGeneratingBase || !baseError ? (
+              <View className="items-center">
+                <View
+                  className="items-center justify-center rounded-[28px] border border-border bg-card"
+                  style={{ width: qrSize + 32, height: qrSize + 32 }}
+                  testID="receive-qr-loading"
+                >
+                  <NoahActivityIndicator />
+                </View>
+                <Text className="mt-6 text-sm text-muted-foreground">
+                  Creating your payment request…
+                </Text>
               </View>
-
-              {bip321Uri ? (
-                <View className="mt-7 items-center">
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel={
-                      isCopied("bip321")
-                        ? "Unified request copied"
-                        : "Copy unified receiving request"
-                    }
-                    accessibilityHint="Copies the unified receiving request to the clipboard"
-                    onPress={() => handleCopyToClipboard(bip321Uri, "bip321")}
-                    className="items-center justify-center rounded-[24px] px-2 py-2"
-                  >
-                    <View className="rounded-[24px] bg-white p-4 shadow-sm shadow-foreground/5">
-                      <QRCode value={bip321Uri} size={190} backgroundColor="white" color="black" />
-                    </View>
-                  </Pressable>
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel={
-                      isCopied("bip321")
-                        ? "Unified request copied"
-                        : "Copy unified receiving request"
-                    }
-                    accessibilityHint="Copies the unified receiving request to the clipboard"
-                    onPress={() => handleCopyToClipboard(bip321Uri, "bip321")}
-                    className="mt-5 flex-row items-center gap-2"
-                  >
-                    <Icon
-                      name={isCopied("bip321") ? "checkmark-circle-outline" : "copy-outline"}
-                      size={17}
-                      color={isCopied("bip321") ? COLORS.SUCCESS : colors.primary}
-                    />
-                    <Text className="text-sm font-semibold text-primary">
-                      {isCopied("bip321") ? "Request copied" : "Tap to copy request"}
-                    </Text>
-                  </Pressable>
-                  <Text className="mt-3 max-w-[270px] text-center text-sm leading-6 text-muted-foreground">
-                    This QR includes every receive rail that generated successfully.
-                  </Text>
-                  {isAmountlessLightningRequest ? (
-                    <Text className="mt-2 max-w-[290px] text-center text-sm leading-6 text-muted-foreground">
-                      Amount required for Lightning.
-                    </Text>
-                  ) : null}
-                </View>
-              ) : null}
-            </View>
-
-            {isGenerated && (
-              <View
-                className="mt-6 overflow-hidden border-t px-1"
-                style={{
-                  borderColor: `${colors.mutedForeground}22`,
-                }}
-              >
-                <View className="flex-row items-center justify-between pt-5">
-                  <Text className="text-sm font-semibold uppercase tracking-[2px] text-muted-foreground">
-                    Available via
-                  </Text>
-                  <Text className="text-xs font-medium uppercase tracking-[2px] text-muted-foreground">
-                    Tap to copy
-                  </Text>
-                </View>
-
-                {arkAddress && (
-                  <>
-                    <PaymentRail
-                      icon="boat-outline"
-                      label="Ark"
-                      value={arkAddress}
-                      onCopy={() => handleCopyToClipboard(arkAddress, "ark")}
-                      isCopied={isCopied("ark")}
-                    />
-                    <View className="h-px bg-border" />
-                  </>
-                )}
-
-                {lightningInvoice ? (
-                  <>
-                    <PaymentRail
-                      icon="flash-outline"
-                      label="Lightning"
-                      value={lightningInvoice.payment_request}
-                      onCopy={() =>
-                        handleCopyToClipboard(lightningInvoice.payment_request, "lightning")
-                      }
-                      isCopied={isCopied("lightning")}
-                    />
-                    <View className="h-px bg-border" />
-                  </>
-                ) : isAmountlessLightningRequest ? (
-                  <>
-                    <PaymentRail
-                      icon="flash-outline"
-                      label="Lightning"
-                      value="Amount required for Lightning"
-                      isCopied={false}
-                      actionLabel="Required"
-                    />
-                    <View className="h-px bg-border" />
-                  </>
-                ) : null}
-
-                {generatedOnchainAddress && (
-                  <PaymentRail
-                    icon="link-outline"
-                    label="On-chain"
-                    value={generatedOnchainAddress}
-                    onCopy={() => handleCopyToClipboard(generatedOnchainAddress, "onchain")}
-                    isCopied={isCopied("onchain")}
-                  />
-                )}
+            ) : (
+              <View className="w-full items-center rounded-[24px] border border-destructive/30 bg-destructive/10 px-6 py-8">
+                <Icon name="warning-outline" size={34} color={DESTRUCTIVE_COLOR} />
+                <Text className="mt-4 text-center text-xl font-bold text-foreground">
+                  Couldn’t create a request
+                </Text>
+                <Text className="mt-2 max-w-[310px] text-center text-sm leading-5 text-muted-foreground">
+                  {baseError?.message ?? "Try again to generate fresh Ark and on-chain addresses."}
+                </Text>
+                <NativeNoahButton
+                  label="Retry"
+                  loadingLabel="Retrying…"
+                  onPress={() => void generateBaseRequest()}
+                  isLoading={isGeneratingBase}
+                  className="mt-6"
+                  testID="receive-retry-button"
+                />
               </View>
             )}
-
-            <View className="mt-5">
-              {!isGenerated && !canGenerateLightningInvoice ? (
-                <Text
-                  className="mb-3 text-center text-sm font-semibold leading-5"
-                  style={{ color: COLORS.BITCOIN_ORANGE }}
-                >
-                  Enter an amount for Lightning
-                </Text>
-              ) : null}
-              <View className="flex-row items-center gap-3">
-                <Button
-                  onPress={handleClear}
-                  disabled={isClearDisabled}
-                  variant="outline"
-                  className="h-14 w-[120px] rounded-2xl"
-                >
-                  <Text className="font-semibold">Clear</Text>
-                </Button>
-                <Button
-                  onPress={handleGenerate}
-                  disabled={isLoading || isDescriptionTooLong}
-                  className="h-14 flex-1 rounded-2xl"
-                  style={{ backgroundColor: COLORS.BITCOIN_ORANGE }}
-                >
-                  <Text className="font-bold" style={{ color: "#1a1a1a" }}>
-                    {isLoading ? "Generating..." : isGenerated ? "New request" : "Generate request"}
-                  </Text>
-                </Button>
-              </View>
-            </View>
           </View>
-        </ScrollView>
-      </TouchableWithoutFeedback>
+
+          {request ? (
+            <View className="gap-3">
+              <NativeNoahButton
+                label={request.amountSat === null ? "Add amount" : "Edit amount"}
+                onPress={() => setIsAmountSheetOpen(true)}
+                disabled={isGeneratingLightning}
+                size="lg"
+                fullWidth
+                testID="receive-amount-button"
+              />
+              <NativeNoahSecondaryButton
+                label="Share"
+                onPress={shareRequest}
+                size="lg"
+                fullWidth
+                testID="receive-share-button"
+              />
+            </View>
+          ) : null}
+        </View>
+      </ScrollView>
+
+      {request ? (
+        <>
+          <ReceiveAmountBottomSheet
+            initialAmountSat={request.amountSat}
+            initialDescription={request.description}
+            isOpen={isAmountSheetOpen}
+            isSubmitting={isGeneratingLightning}
+            onClose={() => setIsAmountSheetOpen(false)}
+            onRemove={removeRequestAmount}
+            onSubmit={(nextAmount) => void submitAmount(nextAmount)}
+          />
+          <ReceiveCopyBottomSheet
+            arkAddress={request.arkAddress}
+            bip321Uri={request.bip321Uri}
+            isOpen={isCopySheetOpen}
+            lightningInvoice={request.lightningInvoice?.payment_request}
+            onClose={() => setIsCopySheetOpen(false)}
+            onchainAddress={request.onchainAddress}
+          />
+        </>
+      ) : null}
+
+      <AppBottomSheet
+        isOpen={isActionsSheetOpen}
+        onClose={() => setIsActionsSheetOpen(false)}
+        onDismiss={() => {
+          if (shouldOpenBoardArkSheet) {
+            setShouldOpenBoardArkSheet(false);
+            setIsBoardArkSheetOpen(true);
+          }
+        }}
+        detents={[0, "content"]}
+      >
+        <View className="pb-4">
+          <Text accessibilityRole="header" className="text-xl font-bold text-foreground">
+            More receive actions
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Board bitcoin to Ark"
+            onPress={openBoardToArk}
+            className="mt-5 flex-row items-center gap-4 rounded-[20px] border border-border bg-card px-4 py-4"
+            testID="receive-board-ark-button"
+          >
+            <View className="h-11 w-11 items-center justify-center rounded-full bg-primary/10">
+              <Icon name="boat-outline" size={21} color={colors.foreground} />
+            </View>
+            <View className="flex-1">
+              <Text className="text-base font-semibold text-foreground">Board to Ark</Text>
+              <Text className="mt-1 text-sm text-muted-foreground">
+                Move on-chain bitcoin into Ark
+              </Text>
+            </View>
+            <Icon name="chevron-forward" size={18} color={colors.mutedForeground} />
+          </Pressable>
+        </View>
+      </AppBottomSheet>
+
       <BoardArkBottomSheet
         isOpen={isBoardArkSheetOpen}
         onClose={() => setIsBoardArkSheetOpen(false)}

--- a/client/src/screens/ReceiveScreen.tsx
+++ b/client/src/screens/ReceiveScreen.tsx
@@ -44,6 +44,11 @@ const ReceiveScreen = () => {
 
   const handleReceiveComplete = useCallback(
     (amountSat: number) => {
+      setIsAmountSheetOpen(false);
+      setIsCopySheetOpen(false);
+      setIsActionsSheetOpen(false);
+      setShouldOpenBoardArkSheet(false);
+      setIsBoardArkSheetOpen(false);
       navigation.navigate("Home", {
         screen: "ReceiveSuccess",
         params: { amountSat },

--- a/client/src/screens/ReceiveScreen.tsx
+++ b/client/src/screens/ReceiveScreen.tsx
@@ -276,7 +276,7 @@ const ReceiveScreen = () => {
         }}
         detents={[0, "content"]}
       >
-        <View className="pb-4">
+        <View>
           <Text accessibilityRole="header" className="text-xl font-bold text-foreground">
             More receive actions
           </Text>

--- a/client/tests/unit/receiveRequest.test.js
+++ b/client/tests/unit/receiveRequest.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+const { buildReceiveRequestUri } = await import("../../src/lib/receiveRequest");
+
+const ONCHAIN_ADDRESS = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+const ARK_ADDRESS =
+  "ark1pwh9vsmezqqpjy9akejayl2vvcse6he97rn40g84xrlvrlnhayuuyefrp9nse2yspqqjl5wpy";
+const LIGHTNING_INVOICE =
+  "lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs";
+
+describe("receive request", () => {
+  test("builds an amountless request with Ark and on-chain payment methods", () => {
+    expect(
+      buildReceiveRequestUri({
+        amountSat: null,
+        arkAddress: ARK_ADDRESS,
+        onchainAddress: ONCHAIN_ADDRESS,
+      }),
+    ).toBe(`bitcoin:${ONCHAIN_ADDRESS}?ark=${ARK_ADDRESS}`);
+  });
+
+  test("builds an amountful request with Lightning and an exact sats amount", () => {
+    expect(
+      buildReceiveRequestUri({
+        amountSat: 500,
+        arkAddress: ARK_ADDRESS,
+        lightningInvoice: LIGHTNING_INVOICE,
+        onchainAddress: ONCHAIN_ADDRESS,
+      }),
+    ).toBe(
+      `bitcoin:${ONCHAIN_ADDRESS}?amount=0.000005&lightning=${LIGHTNING_INVOICE}&ark=${ARK_ADDRESS}`,
+    );
+  });
+
+  test("rejects a zero-sat Lightning request", () => {
+    expect(() =>
+      buildReceiveRequestUri({
+        amountSat: 0,
+        arkAddress: ARK_ADDRESS,
+        lightningInvoice: LIGHTNING_INVOICE,
+        onchainAddress: ONCHAIN_ADDRESS,
+      }),
+    ).toThrow("Receive amount must be a positive whole number of sats");
+  });
+});


### PR DESCRIPTION
## Summary

- replace the form-first Receive screen with an immediately generated Ark + on-chain BIP-321 QR
- add amount entry and editing with a custom keypad, sats/fiat display, optional Lightning note, and fresh BOLT11 generation
- add unified and per-rail copy actions, raw BIP-321 sharing, and retain Board to Ark in the header overflow
- preserve Ark and Lightning receive monitoring while preventing stale edited invoices from affecting the active request
- add focused BIP-321 unit tests and a Maestro receive-flow scenario
- include the regenerated iOS Podfile lock and privacy configuration

## Testing

- `just check` — passes lint, 71 unit tests, and TypeScript
- `nix develop -c just ios-prebuild` — passes after removing Pods, the prior lockfile, and iOS build artifacts
- clean `xcodebuild` of the Noah-Regtest Debug scheme — succeeds with Xcode 26.6
- installed and launched `Noah-Regtest.app` on the iOS 26.5 simulator
- verified the QR-first receive flow with Maestro against the running Docker regtest stack: default Ark/on-chain request, copy sheet, amount entry, Lightning invoice, edit/remove amount, and Share
- two-axis standards/spec review — no hard standards violations or remaining spec findings
