### PR TITLE
Bump Barkd deployments to 0.6.2

### DIFF
--- a/.github/workflows/barkd-build-push.yml
+++ b/.github/workflows/barkd-build-push.yml
@@ -8,7 +8,7 @@ permissions:
   packages: write
 
 env:
-  BARK_VERSION: "0.6.1"
+  BARK_VERSION: "0.6.2"
 
 concurrency:
   group: barkd-image-build

--- a/fly/barkd-setup.md
+++ b/fly/barkd-setup.md
@@ -25,14 +25,14 @@ asset through BuildKit's `TARGETARCH` and verifies a pinned SHA-256 for each arc
 ```sh
 docker build \
   --file fly/barkd.Dockerfile \
-  --tag noah-barkd:0.6.1 \
+  --tag noah-barkd:0.6.2 \
   .
 
-docker run --rm noah-barkd:0.6.1 barkd --version
+docker run --rm noah-barkd:0.6.2 barkd --version
 ```
 
 The manual build workflow builds natively on amd64 and arm64 runners, then publishes shared
-`0.6.1` and `latest` manifests to `niteshbalusu/noah-barkd` on Docker Hub and
+`0.6.2` and `latest` manifests to `niteshbalusu/noah-barkd` on Docker Hub and
 `ghcr.io/smolcars/noah-barkd` on GHCR:
 
 ```sh
@@ -40,7 +40,7 @@ gh workflow run barkd-build-push.yml --ref master
 ```
 
 The workflow uses the existing `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets.
-The Fly configs deliberately use the immutable `0.6.1` tag rather than `latest`, so signet and
+The Fly configs deliberately use the immutable `0.6.2` tag rather than `latest`, so signet and
 mainnet promote the same image version.
 
 ## Provision signet

--- a/fly/barkd.Dockerfile
+++ b/fly/barkd.Dockerfile
@@ -2,10 +2,10 @@
 
 FROM debian:bookworm-slim AS downloader
 
-ARG BARK_VERSION=0.6.1
+ARG BARK_VERSION=0.6.2
 ARG TARGETARCH
-ARG BARKD_SHA256_AMD64=41ca75ae2e474b3a3dbb33f51af95175926abb2286134fcb435fb47b995a1efd
-ARG BARKD_SHA256_ARM64=a078495b095aab9826ccebc921dfad3cc1ae822e1610b94894f9833569552482
+ARG BARKD_SHA256_AMD64=cc38da1b83743c70a2e979e0762da69fbc88d03c6def8bb42fa2c986c0f52fcb
+ARG BARKD_SHA256_ARM64=8fab02cea5dd97299ec73a3ced2ffc6c8cf2a17e17917a300cad948bbb4905b5
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends ca-certificates curl \

--- a/fly/mainnet.barkd.fly.toml
+++ b/fly/mainnet.barkd.fly.toml
@@ -6,7 +6,7 @@ kill_signal = "SIGTERM"
 kill_timeout = "30s"
 
 [build]
-  image = "niteshbalusu/noah-barkd:0.6.1"
+  image = "niteshbalusu/noah-barkd:0.6.2"
 
 [deploy]
   strategy = "rolling"

--- a/fly/signet.barkd.fly.toml
+++ b/fly/signet.barkd.fly.toml
@@ -6,7 +6,7 @@ kill_signal = "SIGTERM"
 kill_timeout = "30s"
 
 [build]
-  image = "niteshbalusu/noah-barkd:0.6.1"
+  image = "niteshbalusu/noah-barkd:0.6.2"
 
 [deploy]
   strategy = "rolling"

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -167,14 +167,14 @@ services:
         condition: service_started
 
   barkd:
-    image: ${BARKD_IMAGE:-niteshbalusu/noah-barkd:0.6.1}
+    image: ${BARKD_IMAGE:-niteshbalusu/noah-barkd:0.6.2}
+    command: ["barkd", "--dangerously-allow-remote-no-auth"]
     restart: on-failure
     network_mode: "service:noah-server"
     environment:
       BARKD_BIND_HOST: 0.0.0.0
       BARKD_BIND_PORT: "3001"
       BARKD_DATADIR: /data/barkd
-      BARKD_NO_AUTH: "true"
     volumes:
       - barkd:/data
     depends_on:


### PR DESCRIPTION
## Summary

- publish Barkd 0.6.2 with the upstream amd64 and arm64 release checksums
- pin the signet, mainnet, and local Compose images to 0.6.2
- adapt local regtest startup to Barkd's explicit remote no-auth flag and refresh the runbook

## Validation

- built and ran the ARM64 image; barkd reports 0.6.2
- built and ran the AMD64 image; barkd reports 0.6.2
- verified the local no-auth flag is accepted
- validated both Fly configs with flyctl --strict
- rendered the Compose config successfully
- matched both checksums against the upstream SHA256SUMS
- passed the commit hook client checks: ESLint, 71 unit tests, and TypeScript

## Rollout

After merge, publish the multi-arch image, deploy and smoke-test signet, then use the production-approved workflow for mainnet.