### PR TITLE
Bump server Bark crates to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,8 +290,8 @@ checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
 name = "ark-lib"
-version = "0.6.1"
-source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.6.1#8134aed9029e4bbd5dff922500affd8611edb511"
+version = "0.6.2"
+source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.6.2#09e5b81d220d16f1e876df4aa772185640301528"
 dependencies = [
  "async-trait",
  "bark-bitcoin-ext",
@@ -947,8 +947,8 @@ dependencies = [
 
 [[package]]
 name = "bark-bitcoin-ext"
-version = "0.6.1"
-source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.6.1#8134aed9029e4bbd5dff922500affd8611edb511"
+version = "0.6.2"
+source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.6.2#09e5b81d220d16f1e876df4aa772185640301528"
 dependencies = [
  "bitcoin",
  "lazy_static",
@@ -959,8 +959,8 @@ dependencies = [
 
 [[package]]
 name = "bark-server-rpc"
-version = "0.6.1"
-source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.6.1#8134aed9029e4bbd5dff922500affd8611edb511"
+version = "0.6.2"
+source = "git+https://gitlab.com/ark-bitcoin/bark?tag=server-0.6.2#09e5b81d220d16f1e876df4aa772185640301528"
 dependencies = [
  "ark-lib",
  "bitcoin",
@@ -5807,6 +5807,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -6769,3 +6770,31 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,8 +26,8 @@ tokio-cron-scheduler = { version = "0.15.1", features = ["english"] }
 serde_json = "1.0.150"
 random_word = { version = "0.5.2", features = ["en"] }
 futures-util = "0.3.32"
-bark-server-rpc = { git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.6.1" }
-ark = { package = "ark-lib", git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.6.1" }
+bark-server-rpc = { git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.6.2" }
+ark = { package = "ark-lib", git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.6.2" }
 deadpool-redis = { version = "0.23.0", features = ["serde", "rt_tokio_1"] }
 redis = { version = "1.4.0", features = ["aio", "tokio-comp"] }
 
@@ -63,7 +63,7 @@ jsonwebtoken = { version = "10.4.0", features = ["aws_lc_rs"] }
 tower = { version = "0.5.3", features = ["full"] }
 tracing-test = "0.2.6"
 once_cell = "1.21.4"
-ark = { package = "ark-lib", git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.6.1", features = [
+ark = { package = "ark-lib", git = "https://gitlab.com/ark-bitcoin/bark", tag = "server-0.6.2", features = [
   "test-util",
 ] }
 


### PR DESCRIPTION
## Summary

- move ark-lib runtime and test dependencies to server-0.6.2
- move bark-server-rpc to the coordinated server-0.6.2 tag
- refresh Cargo.lock, including the new zstd RPC dependency

## Validation

- cargo fmt --check
- cargo check
- cargo test: 373 passed, 0 failed
- cargo build --release --bin noah-cli
- commit hook: ESLint, 71 client unit tests, and TypeScript