### PR TITLE
Improve send UX

### DIFF
--- a/.agents/skills/maestro-expo-debug/SKILL.md
+++ b/.agents/skills/maestro-expo-debug/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: maestro-expo-debug
+description: Write and run Noah Maestro flows against Expo debug or dev-client iOS builds. Use when a Maestro test launches the regtest app, opens the Expo development-client URL, or cannot find Noah UI because Expo's developer-menu tutorial is covering the app.
+---
+
+# Maestro with Expo debug builds
+
+Expo debug builds can show a developer-menu tutorial over Noah. Its X button has the accessibility label `Close`, and the tutorial can reappear after another `launchApp` in the same test run.
+
+Wait for the launch animation, then dismiss the tutorial after opening the development-client URL and after every later `launchApp` before asserting Noah UI:
+
+```yaml
+- waitForAnimationToEnd:
+    timeout: 5000
+- tapOn:
+    text: "Close"
+    optional: true
+```
+
+Keep the action optional so the same flow works when the tutorial was already dismissed or is not present. Use `Close`, not `Continue`; the intended action is the X button.
+
+A typical debug launch starts like this:
+
+```yaml
+- launchApp:
+    clearState: true
+    clearKeychain: true
+- openLink: "exp+noahs-ark-wallet://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A8081"
+- waitForAnimationToEnd:
+    timeout: 5000
+- tapOn:
+    text: "Close"
+    optional: true
+- extendedWaitUntil:
+    visible: "Create Wallet"
+    timeout: 30000
+```
+
+If Noah content is visible behind a large Expo card and an assertion fails, fix the launch flow first. Do not change Noah selectors or production UI until the overlay is ruled out.

--- a/.github/workflows/noah-maestro-test-ios.yml
+++ b/.github/workflows/noah-maestro-test-ios.yml
@@ -98,7 +98,7 @@ jobs:
           done
 
       - name: 🧪 Run Maestro tests
-        run: nix develop .# --command bash -c "xcrun simctl install booted ios-release-build/ios-release.app && bun client maestro:test"
+        run: nix develop .# --command bash -c "xcrun simctl install booted ios-release-build/ios-release.app && bun client maestro:test && scripts/test-send-regtest.sh"
         env:
           MAESTRO_DRIVER_STARTUP_TIMEOUT: 120000
 

--- a/client/.maestro/subflows/prepare-funded-send-ios.yml
+++ b/client/.maestro/subflows/prepare-funded-send-ios.yml
@@ -4,12 +4,6 @@ appId: com.noahwallet.regtest
     clearState: true
     clearKeychain: true
 
-- openLink: "exp+noahs-ark-wallet://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A8081"
-- waitForAnimationToEnd:
-    timeout: 5000
-- tapOn:
-    text: "Close"
-    optional: true
 - extendedWaitUntil:
     visible: "Create Wallet"
     timeout: 30000

--- a/client/.maestro/subflows/prepare-send-wallet-ios.yml
+++ b/client/.maestro/subflows/prepare-send-wallet-ios.yml
@@ -5,6 +5,9 @@ appId: com.noahwallet.regtest
     clearKeychain: true
 
 - openLink: "exp+noahs-ark-wallet://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A8081"
+- tapOn:
+    text: "Close"
+    optional: true
 - extendedWaitUntil:
     visible: "Create Wallet"
     timeout: 30000

--- a/client/.maestro/subflows/prepare-send-wallet-ios.yml
+++ b/client/.maestro/subflows/prepare-send-wallet-ios.yml
@@ -5,6 +5,8 @@ appId: com.noahwallet.regtest
     clearKeychain: true
 
 - openLink: "exp+noahs-ark-wallet://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A8081"
+- waitForAnimationToEnd:
+    timeout: 5000
 - tapOn:
     text: "Close"
     optional: true

--- a/client/.maestro/subflows/prepare-send-wallet-ios.yml
+++ b/client/.maestro/subflows/prepare-send-wallet-ios.yml
@@ -1,0 +1,25 @@
+appId: com.noahwallet.regtest
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+
+- openLink: "exp+noahs-ark-wallet://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A8081"
+- extendedWaitUntil:
+    visible: "Create Wallet"
+    timeout: 30000
+
+- runFlow: start-wallet-onboarding.yml
+- runFlow: complete-wallet-onboarding-without-email.yml
+
+- tapOn: "Receive"
+- extendedWaitUntil:
+    visible:
+      id: "receive-qr-button"
+    timeout: 15000
+- tapOn:
+    id: "receive-qr-button"
+- assertVisible: "Copy payment details"
+- tapOn:
+    id: "receive-copy-ark"
+- tapOn: "Close payment details"

--- a/client/.maestro/subflows/send-amountless-request.yml
+++ b/client/.maestro/subflows/send-amountless-request.yml
@@ -1,0 +1,25 @@
+appId: com.noahwallet.regtest
+---
+- launchApp
+- tapOn: "Send"
+- assertVisible:
+    id: "send-amount-stage"
+- tapOn:
+    id: "send-paste-from-amount"
+- tapOn:
+    text: "Allow Paste"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "send-amount-recipient"
+    timeout: 10000
+- assertNotVisible:
+    id: "send-recipient-stage"
+- assertVisible:
+    id: "send-max"
+- tapOn:
+    id: "send-amount-clear"
+- assertNotVisible:
+    id: "send-amount-recipient"
+- assertVisible:
+    id: "send-paste-from-amount"

--- a/client/.maestro/subflows/send-funded-ark.yml
+++ b/client/.maestro/subflows/send-funded-ark.yml
@@ -1,6 +1,9 @@
 appId: com.noahwallet.regtest
 ---
 - launchApp
+- tapOn:
+    text: "Close"
+    optional: true
 - tapOn: "Send"
 - extendedWaitUntil:
     visible:

--- a/client/.maestro/subflows/send-funded-ark.yml
+++ b/client/.maestro/subflows/send-funded-ark.yml
@@ -1,6 +1,8 @@
 appId: com.noahwallet.regtest
 ---
 - launchApp
+- waitForAnimationToEnd:
+    timeout: 5000
 - tapOn:
     text: "Close"
     optional: true
@@ -10,7 +12,7 @@ appId: com.noahwallet.regtest
       id: "send-amount-stage"
     timeout: 15000
 - extendedWaitUntil:
-    visible: ".*100,000.*available"
+    visible: ".*[1-9][0-9,]* available"
     timeout: 30000
 
 - tapOn:

--- a/client/.maestro/subflows/send-funded-ark.yml
+++ b/client/.maestro/subflows/send-funded-ark.yml
@@ -1,11 +1,6 @@
 appId: com.noahwallet.regtest
 ---
 - launchApp
-- waitForAnimationToEnd:
-    timeout: 5000
-- tapOn:
-    text: "Close"
-    optional: true
 - tapOn: "Send"
 - extendedWaitUntil:
     visible:

--- a/client/.maestro/subflows/send-funded-ark.yml
+++ b/client/.maestro/subflows/send-funded-ark.yml
@@ -16,6 +16,28 @@ appId: com.noahwallet.regtest
     timeout: 30000
 
 - tapOn:
+    id: "send-paste-from-amount"
+- tapOn:
+    text: "Allow Paste"
+    optional: true
+
+- extendedWaitUntil:
+    visible:
+      id: "send-recipient-input"
+    timeout: 10000
+- tapOn:
+    id: "send-recipient-next"
+
+- assertVisible:
+    id: "send-amount-back"
+- tapOn:
+    id: "send-amount-back"
+- assertVisible:
+    id: "send-recipient-input"
+- tapOn:
+    id: "send-recipient-next"
+
+- tapOn:
     id: "send-key-5"
 - tapOn:
     id: "send-key-0"
@@ -25,16 +47,6 @@ appId: com.noahwallet.regtest
     id: "send-key-0"
 - tapOn:
     id: "send-amount-next"
-
-- extendedWaitUntil:
-    visible:
-      id: "send-recipient-input"
-    timeout: 10000
-- tapOn:
-    id: "send-recipient-input"
-- inputText: ${BARK_ARK_ADDRESS}
-- tapOn:
-    id: "send-recipient-next"
 
 - extendedWaitUntil:
     visible:

--- a/client/.maestro/subflows/send-funded-ark.yml
+++ b/client/.maestro/subflows/send-funded-ark.yml
@@ -61,11 +61,9 @@ appId: com.noahwallet.regtest
     timeout: 30000
 - assertVisible: "Payment sent"
 - tapOn:
-    id: "send-success-view-receipt"
-- assertVisible:
-    id: "send-success-receipt"
-- tapOn:
-    id: "send-success-back-to-summary"
+    id: "send-success-copy-destination"
+- assertVisible: "To copied"
+- assertVisible: "Completed"
 - tapOn:
     id: "send-success-done"
 

--- a/client/.maestro/subflows/send-funded-ark.yml
+++ b/client/.maestro/subflows/send-funded-ark.yml
@@ -11,6 +11,11 @@ appId: com.noahwallet.regtest
     timeout: 30000
 
 - tapOn:
+    id: "send-currency-toggle"
+- assertNotVisible: "NaN"
+- tapOn:
+    id: "send-currency-toggle"
+- tapOn:
     id: "send-paste-from-amount"
 - tapOn:
     text: "Allow Paste"

--- a/client/.maestro/subflows/send-funded-ark.yml
+++ b/client/.maestro/subflows/send-funded-ark.yml
@@ -23,19 +23,34 @@ appId: com.noahwallet.regtest
 
 - extendedWaitUntil:
     visible:
-      id: "send-recipient-input"
+      id: "send-amount-recipient"
     timeout: 10000
+- assertNotVisible:
+    id: "send-recipient-stage"
 - tapOn:
-    id: "send-recipient-next"
+    id: "send-amount-change-recipient"
+- assertVisible:
+    id: "send-recipient-stage"
+- tapOn:
+    id: "send-recipient-back"
+- assertVisible:
+    id: "send-amount-recipient"
 
-- assertVisible:
-    id: "send-amount-back"
 - tapOn:
-    id: "send-amount-back"
-- assertVisible:
-    id: "send-recipient-input"
+    id: "send-key-9"
 - tapOn:
-    id: "send-recipient-next"
+    id: "send-amount-clear"
+- assertNotVisible:
+    id: "send-amount-recipient"
+- assertVisible:
+    id: "send-paste-from-amount"
+- tapOn:
+    id: "send-paste-from-amount"
+- tapOn:
+    text: "Allow Paste"
+    optional: true
+- assertVisible:
+    id: "send-amount-recipient"
 
 - tapOn:
     id: "send-key-5"

--- a/client/.maestro/subflows/send-funded-ark.yml
+++ b/client/.maestro/subflows/send-funded-ark.yml
@@ -1,0 +1,60 @@
+appId: com.noahwallet.regtest
+---
+- launchApp
+- tapOn: "Send"
+- extendedWaitUntil:
+    visible:
+      id: "send-amount-stage"
+    timeout: 15000
+- extendedWaitUntil:
+    visible: ".*100,000.*available"
+    timeout: 30000
+
+- tapOn:
+    id: "send-key-5"
+- tapOn:
+    id: "send-key-0"
+- tapOn:
+    id: "send-key-0"
+- tapOn:
+    id: "send-key-0"
+- tapOn:
+    id: "send-amount-next"
+
+- extendedWaitUntil:
+    visible:
+      id: "send-recipient-input"
+    timeout: 10000
+- tapOn:
+    id: "send-recipient-input"
+- inputText: ${BARK_ARK_ADDRESS}
+- tapOn:
+    id: "send-recipient-next"
+
+- extendedWaitUntil:
+    visible:
+      id: "send-review-sheet"
+    timeout: 15000
+- assertVisible: "Pay via"
+- assertVisible: "Ark"
+- tapOn:
+    id: "send-review-confirm"
+
+- extendedWaitUntil:
+    visible:
+      id: "send-success-sheet"
+    timeout: 30000
+- assertVisible: "Payment sent"
+- tapOn:
+    id: "send-success-view-receipt"
+- assertVisible:
+    id: "send-success-receipt"
+- tapOn:
+    id: "send-success-back-to-summary"
+- tapOn:
+    id: "send-success-done"
+
+- assertVisible:
+    id: "send-amount-stage"
+- assertVisible:
+    id: "send-amount-value"

--- a/client/.maestro/subflows/send-funded-ark.yml
+++ b/client/.maestro/subflows/send-funded-ark.yml
@@ -42,6 +42,9 @@ appId: com.noahwallet.regtest
     timeout: 15000
 - assertVisible: "Pay via"
 - assertVisible: "Ark"
+- extendedWaitUntil:
+    visible: "Estimated fee"
+    timeout: 15000
 - tapOn:
     id: "send-review-confirm"
 

--- a/client/.maestro/subflows/send-max-back-fixed-request.yml
+++ b/client/.maestro/subflows/send-max-back-fixed-request.yml
@@ -17,10 +17,6 @@ appId: com.noahwallet.regtest
 - tapOn:
     text: "Allow Paste"
     optional: true
-- assertVisible:
-    id: "send-recipient-stage"
-- tapOn:
-    id: "send-recipient-next"
 - assertNotVisible: "MAX cannot be used with a fixed-amount payment request."
 - extendedWaitUntil:
     visible:
@@ -29,4 +25,6 @@ appId: com.noahwallet.regtest
 - tapOn:
     id: "send-review-back"
 - assertVisible:
+    id: "send-amount-recipient"
+- assertNotVisible:
     id: "send-recipient-stage"

--- a/client/.maestro/subflows/send-max-back-fixed-request.yml
+++ b/client/.maestro/subflows/send-max-back-fixed-request.yml
@@ -1,0 +1,32 @@
+appId: com.noahwallet.regtest
+---
+- launchApp
+- tapOn: "Send"
+- assertVisible:
+    id: "send-amount-stage"
+- tapOn:
+    id: "send-max"
+- assertVisible:
+    id: "send-source-stage"
+- tapOn:
+    id: "send-source-back"
+- assertVisible:
+    id: "send-amount-stage"
+- tapOn:
+    id: "send-paste-from-amount"
+- tapOn:
+    text: "Allow Paste"
+    optional: true
+- assertVisible:
+    id: "send-recipient-stage"
+- tapOn:
+    id: "send-recipient-next"
+- assertNotVisible: "MAX cannot be used with a fixed-amount payment request."
+- extendedWaitUntil:
+    visible:
+      id: "send-review-sheet"
+    timeout: 30000
+- tapOn:
+    id: "send-review-back"
+- assertVisible:
+    id: "send-recipient-stage"

--- a/client/.maestro/subflows/send-recipient-reset-on-back.yml
+++ b/client/.maestro/subflows/send-recipient-reset-on-back.yml
@@ -1,0 +1,45 @@
+appId: com.noahwallet.regtest
+---
+- launchApp
+- tapOn: "Send"
+- assertVisible:
+    id: "send-amount-stage"
+- tapOn:
+    id: "send-key-5"
+- tapOn:
+    id: "send-key-0"
+- tapOn:
+    id: "send-key-0"
+- tapOn:
+    id: "send-key-0"
+- tapOn:
+    id: "send-amount-next"
+- assertVisible:
+    id: "send-recipient-stage"
+- tapOn:
+    id: "send-recipient-paste"
+- tapOn:
+    text: "Allow Paste"
+    optional: true
+- tapOn:
+    id: "send-recipient-next"
+- extendedWaitUntil:
+    visible:
+      id: "send-review-sheet"
+    timeout: 30000
+- tapOn:
+    id: "send-review-back"
+- assertVisible:
+    id: "send-recipient-stage"
+- tapOn:
+    id: "send-recipient-back"
+- assertVisible:
+    id: "send-amount-stage"
+- tapOn:
+    id: "send-key-backspace"
+- tapOn:
+    id: "send-key-4"
+- tapOn:
+    id: "send-amount-next"
+- assertVisible:
+    id: "send-recipient-stage"

--- a/client/src/components/AmountKeypad.tsx
+++ b/client/src/components/AmountKeypad.tsx
@@ -1,4 +1,5 @@
 import Icon from "@react-native-vector-icons/ionicons";
+import * as Haptics from "expo-haptics";
 import { Pressable, View } from "react-native";
 
 import { Text } from "~/components/ui/text";
@@ -35,13 +36,20 @@ export function AmountKeypad({
 }: AmountKeypadProps) {
   const colors = useThemeColors();
 
+  const confirmKeyPress = (nextAmount: string) => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onChange(nextAmount);
+  };
+
   const enterKey = (key: KeypadKey) => {
     if (disabled) {
       return;
     }
 
     if (key === "backspace") {
-      onChange(amount.slice(0, -1));
+      if (amount.length > 0) {
+        confirmKeyPress(amount.slice(0, -1));
+      }
       return;
     }
 
@@ -50,7 +58,7 @@ export function AmountKeypad({
         return;
       }
 
-      onChange(amount.length === 0 ? "0." : `${amount}.`);
+      confirmKeyPress(amount.length === 0 ? "0." : `${amount}.`);
       return;
     }
 
@@ -63,7 +71,7 @@ export function AmountKeypad({
       return;
     }
 
-    onChange(amount === "0" ? key : `${amount}${key}`);
+    confirmKeyPress(amount === "0" ? key : `${amount}${key}`);
   };
 
   return (

--- a/client/src/components/AmountKeypad.tsx
+++ b/client/src/components/AmountKeypad.tsx
@@ -1,0 +1,102 @@
+import Icon from "@react-native-vector-icons/ionicons";
+import * as Haptics from "expo-haptics";
+import { Pressable, View } from "react-native";
+
+import { Text } from "~/components/ui/text";
+import { useThemeColors } from "~/hooks/useTheme";
+
+type AmountCurrency = "FIAT" | "SATS";
+type KeypadKey = "backspace" | "." | `${number}`;
+
+type AmountKeypadProps = {
+  amount: string;
+  currency: AmountCurrency;
+  fiatDecimals: number;
+  onChange: (amount: string) => void;
+  disabled?: boolean;
+  testIDPrefix: string;
+};
+
+const KEYPAD_ROWS: KeypadKey[][] = [
+  ["1", "2", "3"],
+  ["4", "5", "6"],
+  ["7", "8", "9"],
+  [".", "0", "backspace"],
+];
+
+const MAX_AMOUNT_LENGTH = 12;
+
+export function AmountKeypad({
+  amount,
+  currency,
+  fiatDecimals,
+  onChange,
+  disabled = false,
+  testIDPrefix,
+}: AmountKeypadProps) {
+  const colors = useThemeColors();
+
+  const enterKey = (key: KeypadKey) => {
+    if (disabled) {
+      return;
+    }
+
+    void Haptics.selectionAsync();
+
+    if (key === "backspace") {
+      onChange(amount.slice(0, -1));
+      return;
+    }
+
+    if (key === ".") {
+      if (currency !== "FIAT" || fiatDecimals === 0 || amount.includes(".")) {
+        return;
+      }
+
+      onChange(amount.length === 0 ? "0." : `${amount}.`);
+      return;
+    }
+
+    if (amount.length >= MAX_AMOUNT_LENGTH) {
+      return;
+    }
+
+    const decimalPlaces = amount.split(".")[1]?.length ?? 0;
+    if (currency === "FIAT" && amount.includes(".") && decimalPlaces >= fiatDecimals) {
+      return;
+    }
+
+    onChange(amount === "0" ? key : `${amount}${key}`);
+  };
+
+  return (
+    <View accessibilityLabel="Amount keypad">
+      {KEYPAD_ROWS.map((row, rowIndex) => (
+        <View key={rowIndex} className="flex-row">
+          {row.map((key) => {
+            const isDecimalDisabled = key === "." && (currency !== "FIAT" || fiatDecimals === 0);
+
+            return (
+              <Pressable
+                key={key}
+                accessibilityRole="button"
+                accessibilityLabel={key === "backspace" ? "Delete digit" : key}
+                accessibilityState={{ disabled: isDecimalDisabled || disabled }}
+                disabled={isDecimalDisabled || disabled}
+                onPress={() => enterKey(key)}
+                className="h-[66px] flex-1 items-center justify-center"
+                testID={`${testIDPrefix}-${key}`}
+              >
+                {key === "backspace" ? (
+                  <Icon name="backspace-outline" size={27} color={colors.foreground} />
+                ) : isDecimalDisabled ? null : (
+                  <Text className="text-3xl font-medium text-foreground">{key}</Text>
+                )}
+              </Pressable>
+            );
+          })}
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/client/src/components/AmountKeypad.tsx
+++ b/client/src/components/AmountKeypad.tsx
@@ -1,5 +1,4 @@
 import Icon from "@react-native-vector-icons/ionicons";
-import * as Haptics from "expo-haptics";
 import { Pressable, View } from "react-native";
 
 import { Text } from "~/components/ui/text";
@@ -40,8 +39,6 @@ export function AmountKeypad({
     if (disabled) {
       return;
     }
-
-    void Haptics.selectionAsync();
 
     if (key === "backspace") {
       onChange(amount.slice(0, -1));

--- a/client/src/components/QRCodeScanner.tsx
+++ b/client/src/components/QRCodeScanner.tsx
@@ -55,8 +55,11 @@ export const QRCodeScanner = ({ codeScanner, onClose, onPaste }: QRCodeScannerPr
           <View className="flex-row items-center gap-3">
             {onPaste ? (
               <Pressable
+                accessibilityLabel="Paste payment request"
+                accessibilityRole="button"
                 onPress={handlePaste}
                 className="bg-white/20 rounded-full p-4 border border-white/30"
+                testID="qr-scanner-paste"
               >
                 <View className="flex-row items-center justify-center space-x-2">
                   <Icon name="clipboard" size={28} color="white" />
@@ -65,8 +68,11 @@ export const QRCodeScanner = ({ codeScanner, onClose, onPaste }: QRCodeScannerPr
               </Pressable>
             ) : null}
             <Pressable
+              accessibilityLabel="Close scanner"
+              accessibilityRole="button"
               onPress={onClose}
               className="bg-white/20 rounded-full p-4 border border-white/30"
+              testID="qr-scanner-close"
             >
               <View className="flex-row items-center justify-center space-x-2">
                 <Icon name="close-circle" size={28} color="white" />

--- a/client/src/components/ReceiveAmountBottomSheet.tsx
+++ b/client/src/components/ReceiveAmountBottomSheet.tsx
@@ -125,7 +125,7 @@ export function ReceiveAmountBottomSheet({
   };
 
   return (
-    <AppBottomSheet isOpen={isOpen} onClose={close}>
+    <AppBottomSheet isOpen={isOpen} onClose={close} dismissible={!isSubmitting}>
       {isEditingNote ? (
         <View className="flex-1">
           <View className="flex-row items-center justify-between">

--- a/client/src/components/ReceiveAmountBottomSheet.tsx
+++ b/client/src/components/ReceiveAmountBottomSheet.tsx
@@ -5,6 +5,7 @@ import { Keyboard, Pressable, TextInput, View } from "react-native";
 import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
 import { NativeNoahSecondaryButton } from "~/components/ui/NativeNoahSecondaryButton";
 import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
+import { AmountKeypad } from "~/components/AmountKeypad";
 import { Text } from "~/components/ui/text";
 import { useBitcoinAmountFormatter, useBitcoinAmountUnit } from "~/hooks/useBitcoinAmountFormatter";
 import { useReceiveScreen } from "~/hooks/useReceiveScreen";
@@ -27,17 +28,6 @@ type ReceiveAmountBottomSheetProps = {
   onRemove: () => void;
   onSubmit: (request: { amountSat: number; description: string }) => void;
 };
-
-type KeypadKey = "backspace" | "." | `${number}`;
-
-const KEYPAD_ROWS: KeypadKey[][] = [
-  ["1", "2", "3"],
-  ["4", "5", "6"],
-  ["7", "8", "9"],
-  [".", "0", "backspace"],
-];
-
-const MAX_AMOUNT_LENGTH = 12;
 
 export function ReceiveAmountBottomSheet({
   initialAmountSat,
@@ -124,37 +114,6 @@ export function ReceiveAmountBottomSheet({
     Keyboard.dismiss();
     setDescription(noteDraft.trim());
     setIsEditingNote(false);
-  };
-
-  const enterKey = (key: KeypadKey) => {
-    if (isSubmitting) {
-      return;
-    }
-
-    if (key === "backspace") {
-      setAmount(amount.slice(0, -1));
-      return;
-    }
-
-    if (key === ".") {
-      if (currency !== "FIAT" || fiatCurrencyInfo.decimals === 0 || amount.includes(".")) {
-        return;
-      }
-
-      setAmount(amount.length === 0 ? "0." : `${amount}.`);
-      return;
-    }
-
-    if (amount.length >= MAX_AMOUNT_LENGTH) {
-      return;
-    }
-
-    const decimalPlaces = amount.split(".")[1]?.length ?? 0;
-    if (currency === "FIAT" && amount.includes(".") && decimalPlaces >= fiatCurrencyInfo.decimals) {
-      return;
-    }
-
-    setAmount(amount === "0" ? key : `${amount}${key}`);
   };
 
   const submit = () => {
@@ -302,34 +261,15 @@ export function ReceiveAmountBottomSheet({
             </Pressable>
           </View>
 
-          <View accessibilityLabel="Amount keypad" className="mb-5">
-            {KEYPAD_ROWS.map((row, rowIndex) => (
-              <View key={rowIndex} className="flex-row">
-                {row.map((key) => {
-                  const isDecimalDisabled =
-                    key === "." && (currency !== "FIAT" || fiatCurrencyInfo.decimals === 0);
-
-                  return (
-                    <Pressable
-                      key={key}
-                      accessibilityRole="button"
-                      accessibilityLabel={key === "backspace" ? "Delete digit" : key}
-                      accessibilityState={{ disabled: isDecimalDisabled || isSubmitting }}
-                      disabled={isDecimalDisabled || isSubmitting}
-                      onPress={() => enterKey(key)}
-                      className="h-[66px] flex-1 items-center justify-center"
-                      testID={`receive-key-${key}`}
-                    >
-                      {key === "backspace" ? (
-                        <Icon name="backspace-outline" size={27} color={colors.foreground} />
-                      ) : isDecimalDisabled ? null : (
-                        <Text className="text-3xl font-medium text-foreground">{key}</Text>
-                      )}
-                    </Pressable>
-                  );
-                })}
-              </View>
-            ))}
+          <View className="mb-5">
+            <AmountKeypad
+              amount={amount}
+              currency={currency}
+              fiatDecimals={fiatCurrencyInfo.decimals}
+              onChange={setAmount}
+              disabled={isSubmitting}
+              testIDPrefix="receive-key"
+            />
           </View>
 
           <View className="px-1">

--- a/client/src/components/SendConfirmation.tsx
+++ b/client/src/components/SendConfirmation.tsx
@@ -6,13 +6,14 @@ import { Text } from "~/components/ui/text";
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 import { formatFiatAmount, satsToFiat, type FiatCurrencyCode } from "~/lib/fiatCurrency";
 import type { BarkFeeEstimate, OnchainSendSource } from "~/lib/paymentsApi";
-import type { SendRail } from "~/lib/sendFlow";
+import { getOnchainSourceLabel, getSendRailLabel, type SendRail } from "~/lib/sendFlow";
 import type { DestinationTypes, ParsedBip321 } from "~/lib/sendUtils";
 
 type SendConfirmationProps = {
   destination: string;
   amount: number;
   amountNote?: string | null;
+  isMaxAmount?: boolean;
   destinationType: DestinationTypes;
   comment?: string;
   btcPrice?: number;
@@ -55,6 +56,7 @@ export function SendConfirmation({
   destination,
   amount,
   amountNote = null,
+  isMaxAmount = false,
   destinationType,
   comment,
   btcPrice,
@@ -92,20 +94,30 @@ export function SendConfirmation({
     }
     return bip321Data.onchainAddress ?? destination;
   })();
-  const railLabel =
-    selectedRail === "ark" ? "Ark" : selectedRail === "lightning" ? "Lightning" : "On-chain";
-  const sourceLabel =
-    selectedOnchainSource === "offchain"
-      ? "Ark balance"
-      : selectedOnchainSource === "onchain"
-        ? "On-chain wallet"
-        : null;
+  const railLabel = getSendRailLabel(selectedRail);
+  const sourceLabel = selectedOnchainSource
+    ? getOnchainSourceLabel(selectedOnchainSource)
+    : getOnchainSourceLabel("offchain");
   const fiatAmount = btcPrice ? satsToFiat(amount, btcPrice, fiatCurrency) : null;
   const unavailableFeeText =
     feeEstimateUnavailableText ??
     (feeEstimateError
       ? "Fee estimate unavailable. The final fee will be calculated when sending."
       : null);
+  const amountPrefix = isMaxAmount ? (feeEstimate ? "Pay ≈ " : "Pay up to ") : "Pay ";
+  const fiatPrefix = isMaxAmount ? (feeEstimate ? "Estimated ≈ " : "Up to ≈ ") : "≈ ";
+  const feeValue = feeEstimate
+    ? formatBitcoinAmount(feeEstimate.fee_sat)
+    : isEstimatingFee
+      ? "Estimating…"
+      : isMaxAmount
+        ? "Deducted from amount"
+        : "Calculated when sent";
+  const totalValue = feeEstimate
+    ? formatBitcoinAmount(feeEstimate.gross_amount_sat)
+    : isMaxAmount
+      ? formatBitcoinAmount(amount)
+      : `${formatBitcoinAmount(amount)} + fee`;
 
   return (
     <View className="pb-2" testID="send-review-sheet">
@@ -114,11 +126,13 @@ export function SendConfirmation({
           {isLoading ? "Sending payment" : sendError ? "Payment failed" : "Review payment"}
         </Text>
         <Text className="mt-3 text-center text-4xl font-bold text-foreground">
-          Pay {formatBitcoinAmount(amount)}
+          {amountPrefix}
+          {formatBitcoinAmount(amount)}
         </Text>
         {fiatAmount ? (
           <Text className="mt-2 text-base font-medium text-muted-foreground">
-            ≈ {formatFiatAmount(fiatAmount, fiatCurrency)}
+            {fiatPrefix}
+            {formatFiatAmount(fiatAmount, fiatCurrency)}
           </Text>
         ) : null}
         {amountNote ? (
@@ -132,12 +146,8 @@ export function SendConfirmation({
         <ReviewRow label="To" value={truncateValue(resolvedDestination)} />
         <View className="h-px bg-border/60" />
         <ReviewRow label="Pay via" value={railLabel} />
-        {sourceLabel ? (
-          <>
-            <View className="h-px bg-border/60" />
-            <ReviewRow label="Pay from" value={sourceLabel} />
-          </>
-        ) : null}
+        <View className="h-px bg-border/60" />
+        <ReviewRow label="Pay from" value={sourceLabel} />
         <View className="h-px bg-border/60" />
         <ReviewRow
           label="Settlement"
@@ -152,17 +162,9 @@ export function SendConfirmation({
       </View>
 
       <View className="mt-4">
-        {feeEstimate ? (
-          <>
-            <ReviewRow label="Estimated fee" value={formatBitcoinAmount(feeEstimate.fee_sat)} />
-            <ReviewRow
-              label="Total deducted"
-              value={formatBitcoinAmount(feeEstimate.gross_amount_sat)}
-            />
-          </>
-        ) : isEstimatingFee ? (
-          <ReviewRow label="Fee" value="Estimating…" />
-        ) : unavailableFeeText ? (
+        <ReviewRow label={feeEstimate ? "Estimated fee" : "Fee"} value={feeValue} />
+        <ReviewRow label="Total deducted" value={totalValue} />
+        {unavailableFeeText ? (
           <Text className="text-sm leading-5 text-muted-foreground">{unavailableFeeText}</Text>
         ) : null}
         {feeEstimateNote ? (

--- a/client/src/components/SendConfirmation.tsx
+++ b/client/src/components/SendConfirmation.tsx
@@ -1,18 +1,15 @@
-import React from "react";
-import { Pressable, View } from "react-native";
-import { Text } from "./ui/text";
-import { Button } from "./ui/button";
-import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
-import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
-import { DestinationTypes, ParsedBip321 } from "~/lib/sendUtils";
-import { useThemeColors } from "~/hooks/useTheme";
-import { COLORS } from "~/lib/styleConstants";
-import { Bip321Picker } from "./Bip321Picker";
-import { FeeEstimateSummary } from "./FeeEstimateSummary";
-import type { BarkFeeEstimate, OnchainSendSource } from "~/lib/paymentsApi";
-import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
+import { View } from "react-native";
 
-interface SendConfirmationProps {
+import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
+import { NativeNoahSecondaryButton } from "~/components/ui/NativeNoahSecondaryButton";
+import { Text } from "~/components/ui/text";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
+import { formatFiatAmount, satsToFiat, type FiatCurrencyCode } from "~/lib/fiatCurrency";
+import type { BarkFeeEstimate, OnchainSendSource } from "~/lib/paymentsApi";
+import type { SendRail } from "~/lib/sendFlow";
+import type { DestinationTypes, ParsedBip321 } from "~/lib/sendUtils";
+
+type SendConfirmationProps = {
   destination: string;
   amount: number;
   amountNote?: string | null;
@@ -22,12 +19,8 @@ interface SendConfirmationProps {
   fiatCurrency: FiatCurrencyCode;
   bip321Data?: ParsedBip321 | null;
   selectedPaymentMethod?: "ark" | "lightning" | "onchain" | "offer";
-  onSelectPaymentMethod?: (type: "ark" | "lightning" | "onchain" | "offer") => void;
-  onchainSourceOptions?: OnchainSendSource[];
+  selectedRail: SendRail;
   selectedOnchainSource?: OnchainSendSource | null;
-  onSelectOnchainSource?: (source: OnchainSendSource) => void;
-  onchainWalletBalance?: number;
-  offchainWalletBalance?: number;
   onConfirm: () => void;
   onCancel: () => void;
   isConfirmDisabled?: boolean;
@@ -39,17 +32,26 @@ interface SendConfirmationProps {
   feeEstimateNote?: string | null;
   feeEstimateWarning?: string | null;
   sendError?: string | null;
-}
+};
 
 const truncateValue = (value: string) => {
   if (value.length <= 32) {
     return value;
   }
 
-  return `${value.slice(0, 14)}...${value.slice(-10)}`;
+  return `${value.slice(0, 14)}…${value.slice(-10)}`;
 };
 
-export const SendConfirmation: React.FC<SendConfirmationProps> = ({
+const ReviewRow = ({ label, value }: { label: string; value: string }) => (
+  <View className="flex-row items-start justify-between gap-5 py-3">
+    <Text className="text-base text-muted-foreground">{label}</Text>
+    <Text className="min-w-0 flex-1 text-right text-base font-semibold text-foreground">
+      {value}
+    </Text>
+  </View>
+);
+
+export function SendConfirmation({
   destination,
   amount,
   amountNote = null,
@@ -59,12 +61,8 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
   fiatCurrency,
   bip321Data,
   selectedPaymentMethod,
-  onSelectPaymentMethod,
-  onchainSourceOptions = [],
+  selectedRail,
   selectedOnchainSource = null,
-  onSelectOnchainSource,
-  onchainWalletBalance = 0,
-  offchainWalletBalance = 0,
   onConfirm,
   onCancel,
   isConfirmDisabled = false,
@@ -76,225 +74,104 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
   feeEstimateNote = null,
   feeEstimateWarning = null,
   sendError = null,
-}) => {
+}: SendConfirmationProps) {
   const formatBitcoinAmount = useBitcoinAmountFormatter();
-  const colors = useThemeColors();
-  const isOnchainDestination =
-    destinationType === "onchain" ||
-    (destinationType === "bip321" && selectedPaymentMethod === "onchain");
 
-  const getOnchainSourceLabel = (source: OnchainSendSource) =>
-    source === "offchain" ? "Ark balance" : "Onchain wallet";
-
-  const getOnchainSourceBalance = (source: OnchainSendSource) =>
-    source === "offchain" ? offchainWalletBalance : onchainWalletBalance;
-
-  const getPaymentMethodLabel = () => {
-    if (destinationType === "bip321") {
-      switch (selectedPaymentMethod) {
-        case "ark":
-          return "Ark";
-        case "lightning":
-          return "Lightning";
-        case "offer":
-          return "Offer";
-        case "onchain":
-        default:
-          return "On-chain";
-      }
+  const resolvedDestination = (() => {
+    if (destinationType !== "bip321" || !bip321Data) {
+      return destination;
     }
-
-    switch (destinationType) {
-      case "ark":
-        return "Ark";
-      case "lightning":
-        return "Lightning";
-      case "lnurl":
-        return "Lightning Address";
-      case "onchain":
-        return "On-chain";
-      case "offer":
-        return "Offer";
-      default:
-        return "Bitcoin";
+    if (selectedPaymentMethod === "ark") {
+      return bip321Data.arkAddress ?? destination;
     }
-  };
-
-  const getDestinationDisplay = () => {
-    if (destinationType === "bip321" && bip321Data) {
-      if (selectedPaymentMethod === "ark" && bip321Data.arkAddress) {
-        return bip321Data.arkAddress;
-      }
-
-      if (selectedPaymentMethod === "lightning" && bip321Data.lightningInvoice) {
-        return bip321Data.lightningInvoice;
-      }
-
-      if (selectedPaymentMethod === "offer" && bip321Data.offer) {
-        return bip321Data.offer;
-      }
-
-      if (selectedPaymentMethod === "onchain" && bip321Data.onchainAddress) {
-        return bip321Data.onchainAddress;
-      }
+    if (selectedPaymentMethod === "lightning") {
+      return bip321Data.lightningInvoice ?? destination;
     }
-
-    return destination;
-  };
-
+    if (selectedPaymentMethod === "offer") {
+      return bip321Data.offer ?? destination;
+    }
+    return bip321Data.onchainAddress ?? destination;
+  })();
+  const railLabel =
+    selectedRail === "ark" ? "Ark" : selectedRail === "lightning" ? "Lightning" : "On-chain";
+  const sourceLabel =
+    selectedOnchainSource === "offchain"
+      ? "Ark balance"
+      : selectedOnchainSource === "onchain"
+        ? "On-chain wallet"
+        : null;
   const fiatAmount = btcPrice ? satsToFiat(amount, btcPrice, fiatCurrency) : null;
-  const resolvedDestination = getDestinationDisplay();
-  const title = isLoading ? "Sending payment" : sendError ? "Send failed" : "Confirm send";
-  const description = isLoading
-    ? "Keep Noah open while this completes."
-    : sendError
-      ? "Review the error, then retry or cancel."
-      : "Review the route and fee before sending.";
+  const unavailableFeeText =
+    feeEstimateUnavailableText ??
+    (feeEstimateError
+      ? "Fee estimate unavailable. The final fee will be calculated when sending."
+      : null);
 
   return (
-    <View>
+    <View className="pb-2" testID="send-review-sheet">
       <View className="items-center">
-        <Text className="text-center text-2xl font-bold text-foreground">{title}</Text>
-        <Text className="mt-1 max-w-[280px] text-center text-sm text-muted-foreground">
-          {description}
+        <Text className="text-center text-sm font-semibold uppercase tracking-[2px] text-muted-foreground">
+          {isLoading ? "Sending payment" : sendError ? "Payment failed" : "Review payment"}
         </Text>
-      </View>
-
-      <View className="mt-4 items-center">
-        <Text className="text-center text-3xl font-bold text-foreground">
-          {formatBitcoinAmount(amount)}
+        <Text className="mt-3 text-center text-4xl font-bold text-foreground">
+          Pay {formatBitcoinAmount(amount)}
         </Text>
+        {fiatAmount ? (
+          <Text className="mt-2 text-base font-medium text-muted-foreground">
+            ≈ {formatFiatAmount(fiatAmount, fiatCurrency)}
+          </Text>
+        ) : null}
         {amountNote ? (
-          <Text className="mt-1 max-w-[300px] text-center text-sm text-muted-foreground">
+          <Text className="mt-2 max-w-[310px] text-center text-sm leading-5 text-muted-foreground">
             {amountNote}
           </Text>
-        ) : btcPrice ? (
-          <Text className="mt-1 text-sm font-medium text-muted-foreground">
-            ≈ {fiatAmount ? formatFiatAmount(fiatAmount, fiatCurrency) : null}
-          </Text>
         ) : null}
       </View>
 
-      <View
-        className="mt-5 rounded-[20px] border px-4 py-4"
-        style={{
-          borderColor: `${colors.mutedForeground}22`,
-          backgroundColor: `${colors.card}CC`,
-        }}
-      >
-        <View className="flex-row items-center justify-between">
-          <Text className="text-xs font-medium uppercase tracking-[2px] text-muted-foreground">
-            Route
-          </Text>
-          {destinationType !== "bip321" ? (
-            <Text className="text-sm font-semibold" style={{ color: COLORS.BITCOIN_ORANGE }}>
-              {getPaymentMethodLabel()}
-            </Text>
-          ) : null}
-        </View>
-
-        {destinationType === "bip321" &&
-        bip321Data &&
-        selectedPaymentMethod &&
-        onSelectPaymentMethod ? (
-          <Bip321Picker
-            bip321Data={bip321Data}
-            selectedPaymentMethod={selectedPaymentMethod}
-            onSelect={isLoading ? () => undefined : onSelectPaymentMethod}
-            showSectionHeader={false}
-            showSelectedDestination={false}
-          />
-        ) : (
-          <View className="mt-3 h-px bg-border" />
-        )}
-
-        {isOnchainDestination && onchainSourceOptions.length > 0 ? (
+      <View className="mt-6 border-y border-border/70 py-1">
+        <ReviewRow label="To" value={truncateValue(resolvedDestination)} />
+        <View className="h-px bg-border/60" />
+        <ReviewRow label="Pay via" value={railLabel} />
+        {sourceLabel ? (
           <>
-            <View className="h-px bg-border" />
-            <View className="py-3">
-              <Text className="text-xs font-medium uppercase tracking-[2px] text-muted-foreground">
-                Send from
-              </Text>
-              {onchainSourceOptions.length > 1 && onSelectOnchainSource ? (
-                <View className="mt-3 flex-row gap-2">
-                  {onchainSourceOptions.map((source) => {
-                    const isSelected = selectedOnchainSource === source;
-                    return (
-                      <Pressable
-                        key={source}
-                        onPress={() => onSelectOnchainSource(source)}
-                        disabled={isLoading}
-                        className="flex-1 rounded-2xl border px-3 py-3"
-                        style={{
-                          borderColor: isSelected
-                            ? COLORS.BITCOIN_ORANGE
-                            : `${colors.mutedForeground}26`,
-                          backgroundColor: isSelected
-                            ? "rgba(201, 138, 60, 0.14)"
-                            : `${colors.card}99`,
-                          opacity: isLoading ? 0.65 : 1,
-                        }}
-                      >
-                        <Text
-                          className={`text-sm font-semibold ${
-                            isSelected ? "text-foreground" : "text-muted-foreground"
-                          }`}
-                        >
-                          {getOnchainSourceLabel(source)}
-                        </Text>
-                        <Text className="mt-1 text-xs text-muted-foreground">
-                          {formatBitcoinAmount(getOnchainSourceBalance(source))}
-                        </Text>
-                      </Pressable>
-                    );
-                  })}
-                </View>
-              ) : selectedOnchainSource ? (
-                <Text className="mt-1 text-sm font-semibold text-foreground">
-                  {getOnchainSourceLabel(selectedOnchainSource)}
-                </Text>
-              ) : null}
-            </View>
+            <View className="h-px bg-border/60" />
+            <ReviewRow label="Pay from" value={sourceLabel} />
           </>
         ) : null}
-
-        <View className="py-3">
-          <Text className="text-xs font-medium uppercase tracking-[2px] text-muted-foreground">
-            Destination
-          </Text>
-          <Text className="mt-1 text-sm leading-5 text-foreground">
-            {truncateValue(resolvedDestination)}
-          </Text>
-        </View>
-
+        <View className="h-px bg-border/60" />
+        <ReviewRow
+          label="Settlement"
+          value={selectedRail === "onchain" ? "Requires network confirmation" : "Usually instant"}
+        />
         {comment ? (
           <>
-            <View className="h-px bg-border" />
-            <View className="pt-3">
-              <Text className="text-xs font-medium uppercase tracking-[2px] text-muted-foreground">
-                Note
-              </Text>
-              <Text className="mt-1 text-sm leading-5 text-foreground" numberOfLines={2}>
-                {comment}
-              </Text>
-            </View>
+            <View className="h-px bg-border/60" />
+            <ReviewRow label="Note" value={comment} />
           </>
         ) : null}
       </View>
 
-      <FeeEstimateSummary
-        estimate={feeEstimate}
-        isLoading={isEstimatingFee}
-        error={
-          feeEstimateUnavailableText ? new Error(feeEstimateUnavailableText) : feeEstimateError
-        }
-        unavailableText={feeEstimateUnavailableText ?? undefined}
-        note={feeEstimateNote}
-        compact
-      />
+      <View className="mt-4">
+        {feeEstimate ? (
+          <>
+            <ReviewRow label="Estimated fee" value={formatBitcoinAmount(feeEstimate.fee_sat)} />
+            <ReviewRow
+              label="Total deducted"
+              value={formatBitcoinAmount(feeEstimate.gross_amount_sat)}
+            />
+          </>
+        ) : isEstimatingFee ? (
+          <ReviewRow label="Fee" value="Estimating…" />
+        ) : unavailableFeeText ? (
+          <Text className="text-sm leading-5 text-muted-foreground">{unavailableFeeText}</Text>
+        ) : null}
+        {feeEstimateNote ? (
+          <Text className="mt-2 text-xs leading-5 text-muted-foreground">{feeEstimateNote}</Text>
+        ) : null}
+      </View>
 
       {feeEstimateWarning ? (
-        <View className="mt-3 rounded-2xl border border-amber-500/40 bg-amber-500/10 px-4 py-3">
+        <View className="mt-4 rounded-2xl border border-amber-500/40 bg-amber-500/10 px-4 py-3">
           <Text className="text-sm leading-5 text-amber-700 dark:text-amber-200">
             {feeEstimateWarning}
           </Text>
@@ -302,32 +179,32 @@ export const SendConfirmation: React.FC<SendConfirmationProps> = ({
       ) : null}
 
       {sendError ? (
-        <View className="mt-3 rounded-2xl border border-destructive/35 bg-destructive/10 px-4 py-3">
+        <View className="mt-4 rounded-2xl border border-destructive/35 bg-destructive/10 px-4 py-3">
           <Text className="text-sm font-semibold text-destructive">Payment did not send</Text>
           <Text className="mt-1 text-sm leading-5 text-destructive/90">{sendError}</Text>
         </View>
       ) : null}
 
-      <View className="mt-5 flex-row gap-3">
-        <Button
+      <View className="mt-6 gap-3">
+        <NativeNoahSecondaryButton
+          label="Back"
           onPress={onCancel}
-          variant="outline"
           disabled={isLoading}
-          className="flex-1 rounded-2xl py-3"
-        >
-          <Text className="font-semibold">Cancel</Text>
-        </Button>
-        <Button
+          size="lg"
+          fullWidth
+          testID="send-review-back"
+        />
+        <NativeNoahButton
+          label={sendError ? "Retry payment" : "Confirm payment"}
+          loadingLabel="Sending…"
           onPress={onConfirm}
-          disabled={isLoading || isConfirmDisabled}
-          className="flex-1 rounded-2xl py-3"
-          style={{ backgroundColor: COLORS.BITCOIN_ORANGE }}
-        >
-          <Text className="font-bold" style={{ color: "#1a1a1a" }}>
-            {isLoading ? "Sending..." : "Confirm & Send"}
-          </Text>
-        </Button>
+          disabled={isConfirmDisabled}
+          isLoading={isLoading}
+          size="lg"
+          fullWidth
+          testID="send-review-confirm"
+        />
       </View>
     </View>
   );
-};
+}

--- a/client/src/components/SendSuccessBottomSheet.tsx
+++ b/client/src/components/SendSuccessBottomSheet.tsx
@@ -1,27 +1,15 @@
 import Icon from "@react-native-vector-icons/ionicons";
 import * as Haptics from "expo-haptics";
 import React, { useEffect, useState } from "react";
-import { Image, Pressable, View } from "react-native";
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useReducedMotion,
-  useSharedValue,
-  withDelay,
-  withSequence,
-  withTiming,
-} from "react-native-reanimated";
+import { Pressable, View } from "react-native";
 
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
-import { useTheme } from "~/hooks/useTheme";
 import { useCopyToClipboard } from "~/lib/clipboardUtils";
 import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
 import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
 import { COLORS } from "~/lib/styleConstants";
 import { NativeNoahButton } from "./ui/NativeNoahButton";
-import { NativeNoahSecondaryButton } from "./ui/NativeNoahSecondaryButton";
 import { Text } from "./ui/text";
-import noahIcon from "../../assets/icon.png";
 
 type ParsedResult = {
   amount_sat: number;
@@ -38,40 +26,6 @@ type SendSuccessBottomSheetProps = {
   btcPrice?: number;
   fiatCurrency: FiatCurrencyCode;
 };
-
-const PAPER_TRAVEL = 440;
-const PAPER_COLOR = "#fffaf0";
-const PAPER_INK = "#24211d";
-const PAPER_MUTED_INK = "#746e64";
-const PAPER_TEETH = Array.from({ length: 18 }, (_, index) => index);
-const DARK_PRINTER_COLORS = {
-  shell: "#292a2d",
-  shellBorder: "#46474b",
-  header: "rgba(255, 255, 255, 0.7)",
-  headerMuted: "rgba(255, 255, 255, 0.6)",
-  screen: "#151618",
-  screenBorder: "#343539",
-  screenForeground: "#ffffff",
-  screenMuted: "rgba(255, 255, 255, 0.45)",
-  screenStatus: "rgba(255, 255, 255, 0.7)",
-  divider: "rgba(255, 255, 255, 0.1)",
-  slot: "#0d0e10",
-  slotBorder: "#45464b",
-} as const;
-const LIGHT_PRINTER_COLORS = {
-  shell: "#e1e7ee",
-  shellBorder: "#bec9d4",
-  header: "#465263",
-  headerMuted: "#657284",
-  screen: "#f8fafc",
-  screenBorder: "#c4ced9",
-  screenForeground: "#182332",
-  screenMuted: "#657284",
-  screenStatus: "#465263",
-  divider: "#d7dfe8",
-  slot: "#272e37",
-  slotBorder: "#66717d",
-} as const;
 
 const truncateValue = (value: string) => {
   if (value.length <= 32) {
@@ -95,48 +49,49 @@ const formatCompletedAt = (date: Date) => {
   return `${day} · ${time}`;
 };
 
-const ReceiptDivider = () => (
-  <View className="my-5 border-t" style={{ borderColor: "#c9c1b4", borderStyle: "dashed" }} />
+const DetailRow = ({ label, value }: { label: string; value: string }) => (
+  <View className="flex-row items-start justify-between gap-5 border-b border-border/60 py-4">
+    <Text className="text-base text-muted-foreground">{label}</Text>
+    <Text className="min-w-0 flex-1 text-right text-base font-semibold text-foreground">
+      {value}
+    </Text>
+  </View>
 );
 
-const ReceiptCopyRow = ({
+const CopyDetailRow = ({
   label,
   value,
   copyId,
+  testID,
 }: {
   label: string;
   value: string;
   copyId: string;
+  testID: string;
 }) => {
-  const { copyWithState, isCopied } = useCopyToClipboard(1200);
+  const { copyWithState, isCopied } = useCopyToClipboard(3000);
   const copied = isCopied(copyId);
   const displayedValue = truncateValue(value);
 
   return (
     <Pressable
-      accessibilityHint="Copies the full receipt detail to the clipboard"
-      accessibilityLabel={`Copy ${label}: ${displayedValue}`}
+      accessibilityHint="Copies the full payment detail to the clipboard"
+      accessibilityLabel={copied ? `${label} copied` : `Copy ${label}: ${displayedValue}`}
       accessibilityRole="button"
+      className="flex-row items-start justify-between gap-5 border-b border-border/60 py-4"
       onPress={() => copyWithState(value, copyId)}
-      className="flex-row items-start justify-between gap-3 py-2"
+      testID={testID}
     >
-      <View className="min-w-0 flex-1">
+      <Text className="text-base text-muted-foreground">{label}</Text>
+      <View className="min-w-0 flex-1 items-end">
+        <Text className="text-right text-base font-semibold text-foreground">{displayedValue}</Text>
         <Text
-          className="font-mono text-[10px] uppercase tracking-[1.8px]"
-          style={{ color: PAPER_MUTED_INK }}
+          className="mt-1 text-xs font-semibold uppercase tracking-[1.4px]"
+          style={{ color: copied ? COLORS.SUCCESS : COLORS.BITCOIN_ORANGE }}
         >
-          {label}
-        </Text>
-        <Text className="mt-1 font-mono text-xs leading-5" style={{ color: PAPER_INK }}>
-          {displayedValue}
+          {copied ? "Copied" : "Copy"}
         </Text>
       </View>
-      <Text
-        className="pt-1 font-mono text-[10px] font-bold uppercase tracking-[1.4px]"
-        style={{ color: copied ? COLORS.SUCCESS : COLORS.BITCOIN_ORANGE }}
-      >
-        {copied ? "Copied" : "Copy"}
-      </Text>
     </Pressable>
   );
 };
@@ -148,335 +103,59 @@ export const SendSuccessBottomSheet: React.FC<SendSuccessBottomSheetProps> = ({
   fiatCurrency,
 }) => {
   const formatBitcoinAmount = useBitcoinAmountFormatter();
-  const { isDark } = useTheme();
-  const shouldReduceMotion = useReducedMotion();
   const [completedAt] = useState(() => new Date());
-  const [showReceipt, setShowReceipt] = useState(false);
-  const paperOffset = useSharedValue(shouldReduceMotion ? 0 : -PAPER_TRAVEL);
-  const paperOpacity = useSharedValue(shouldReduceMotion ? 1 : 0);
   const fiatAmount = btcPrice ? satsToFiat(parsedResult.amount_sat, btcPrice, fiatCurrency) : null;
   const proofLabel = parsedResult.txid ? "Transaction ID" : "Payment preimage";
   const proofValue = parsedResult.txid ?? parsedResult.preimage;
-  const referenceSource = proofValue ?? parsedResult.destination;
-  const reference = referenceSource.slice(-12).toUpperCase();
-  const printerColors = isDark ? DARK_PRINTER_COLORS : LIGHT_PRINTER_COLORS;
 
   useEffect(() => {
-    const hapticTimer = setTimeout(
-      () => {
-        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-      },
-      shouldReduceMotion ? 0 : 220,
-    );
-
-    if (shouldReduceMotion) {
-      paperOffset.value = 0;
-      paperOpacity.value = 1;
-    } else {
-      paperOpacity.value = withDelay(180, withTiming(1, { duration: 100 }));
-      paperOffset.value = withDelay(
-        180,
-        withSequence(
-          withTiming(-360, { duration: 120, easing: Easing.linear }),
-          withDelay(45, withTiming(-285, { duration: 150, easing: Easing.linear })),
-          withDelay(45, withTiming(-210, { duration: 150, easing: Easing.linear })),
-          withDelay(45, withTiming(-135, { duration: 150, easing: Easing.linear })),
-          withDelay(45, withTiming(-65, { duration: 150, easing: Easing.linear })),
-          withDelay(45, withTiming(0, { duration: 180, easing: Easing.out(Easing.cubic) })),
-        ),
-      );
-    }
-
-    return () => clearTimeout(hapticTimer);
-  }, [paperOffset, paperOpacity, shouldReduceMotion]);
-
-  const paperAnimatedStyle = useAnimatedStyle(() => ({
-    opacity: paperOpacity.value,
-    transform: [{ translateY: paperOffset.value }],
-  }));
-
-  if (!showReceipt) {
-    return (
-      <View className="pb-2" testID="send-success-sheet">
-        <View className="items-center px-5 pt-8">
-          <View className="size-20 items-center justify-center rounded-full bg-success/15">
-            <Icon name="checkmark" size={48} color={COLORS.SUCCESS} />
-          </View>
-          <Text className="mt-7 text-center text-4xl font-bold text-foreground">Payment sent</Text>
-          <Text className="mt-3 text-center text-3xl font-semibold text-foreground">
-            {formatBitcoinAmount(parsedResult.amount_sat)}
-          </Text>
-          {fiatAmount ? (
-            <Text className="mt-2 text-base text-muted-foreground">
-              ≈ {formatFiatAmount(fiatAmount, fiatCurrency)}
-            </Text>
-          ) : null}
-
-          <View className="mt-8 w-full border-y border-border/70 py-4">
-            <View className="flex-row items-center justify-between gap-5">
-              <Text className="text-base text-muted-foreground">Paid via</Text>
-              <Text className="text-base font-semibold text-foreground">{parsedResult.type}</Text>
-            </View>
-            <View className="mt-4 flex-row items-start justify-between gap-5">
-              <Text className="text-base text-muted-foreground">To</Text>
-              <Text className="min-w-0 flex-1 text-right text-base font-semibold text-foreground">
-                {truncateValue(parsedResult.destination)}
-              </Text>
-            </View>
-          </View>
-        </View>
-
-        <View className="mt-10 gap-3 px-1">
-          <NativeNoahSecondaryButton
-            label="View receipt"
-            onPress={() => setShowReceipt(true)}
-            size="lg"
-            fullWidth
-            testID="send-success-view-receipt"
-          />
-          <NativeNoahButton
-            label="Done"
-            onPress={handleDone}
-            size="lg"
-            fullWidth
-            testID="send-success-done"
-          />
-        </View>
-      </View>
-    );
-  }
+    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  }, []);
 
   return (
-    <View className="pb-2" testID="send-success-receipt">
-      <View className="mb-4 px-1">
-        <NativeNoahSecondaryButton
-          label="Back to summary"
-          onPress={() => setShowReceipt(false)}
+    <View className="pb-2" testID="send-success-sheet">
+      <View className="items-center px-5 pt-8">
+        <View className="size-20 items-center justify-center rounded-full bg-success/15">
+          <Icon name="checkmark" size={48} color={COLORS.SUCCESS} />
+        </View>
+        <Text className="mt-7 text-center text-4xl font-bold text-foreground">Payment sent</Text>
+        <Text className="mt-3 text-center text-3xl font-semibold text-foreground">
+          {formatBitcoinAmount(parsedResult.amount_sat)}
+        </Text>
+        {fiatAmount ? (
+          <Text className="mt-2 text-base text-muted-foreground">
+            ≈ {formatFiatAmount(fiatAmount, fiatCurrency)}
+          </Text>
+        ) : null}
+
+        <View className="mt-8 w-full border-t border-border/60">
+          <DetailRow label="Paid via" value={parsedResult.type} />
+          <CopyDetailRow
+            label="To"
+            value={parsedResult.destination}
+            copyId="success-destination"
+            testID="send-success-copy-destination"
+          />
+          {proofValue ? (
+            <CopyDetailRow
+              label={proofLabel}
+              value={proofValue}
+              copyId="success-proof"
+              testID="send-success-copy-proof"
+            />
+          ) : null}
+          <DetailRow label="Completed" value={formatCompletedAt(completedAt)} />
+        </View>
+      </View>
+
+      <View className="mt-8 px-1">
+        <NativeNoahButton
+          label="Done"
+          onPress={handleDone}
+          size="lg"
           fullWidth
-          testID="send-success-back-to-summary"
+          testID="send-success-done"
         />
-      </View>
-      <View className="items-center px-1">
-        <View
-          className="z-20 w-full rounded-[30px] border px-4 pt-4 pb-12"
-          style={{
-            backgroundColor: printerColors.shell,
-            borderColor: printerColors.shellBorder,
-            shadowColor: "#000000",
-            shadowOffset: { width: 0, height: 16 },
-            shadowOpacity: isDark ? 0.28 : 0.16,
-            shadowRadius: 22,
-            elevation: 12,
-          }}
-        >
-          <View className="mb-4 flex-row items-center justify-between px-1">
-            <View className="flex-row items-center gap-2">
-              <Image
-                accessibilityIgnoresInvertColors
-                accessible={false}
-                className="size-7 rounded-lg"
-                resizeMode="cover"
-                source={noahIcon}
-              />
-              <Text
-                className="text-xs font-semibold uppercase tracking-[2.5px]"
-                style={{ color: printerColors.header }}
-              >
-                Noah receipt
-              </Text>
-            </View>
-            <View className="flex-row items-center gap-1.5">
-              <View className="size-2 rounded-full" style={{ backgroundColor: COLORS.SUCCESS }} />
-              <Text
-                className="text-[10px] font-semibold uppercase tracking-[1.8px]"
-                style={{ color: printerColors.headerMuted }}
-              >
-                Complete
-              </Text>
-            </View>
-          </View>
-
-          <View
-            className="rounded-[21px] border px-4 py-4"
-            style={{
-              backgroundColor: printerColors.screen,
-              borderColor: printerColors.screenBorder,
-            }}
-          >
-            <View className="flex-row items-start justify-between gap-4">
-              <View className="min-w-0 flex-1">
-                <Text
-                  className="text-xs font-medium uppercase tracking-[1.8px]"
-                  style={{ color: printerColors.screenMuted }}
-                >
-                  Sent via
-                </Text>
-                <Text
-                  className="mt-1 text-base font-semibold"
-                  numberOfLines={1}
-                  style={{ color: printerColors.screenForeground }}
-                >
-                  {parsedResult.type}
-                </Text>
-              </View>
-              <View className="items-end">
-                <Text
-                  className="text-xs font-medium uppercase tracking-[1.8px]"
-                  style={{ color: printerColors.screenMuted }}
-                >
-                  Total
-                </Text>
-                <Text
-                  className="mt-1 text-lg font-bold"
-                  style={{ color: printerColors.screenForeground }}
-                >
-                  {formatBitcoinAmount(parsedResult.amount_sat)}
-                </Text>
-              </View>
-            </View>
-
-            <View className="my-4 h-px" style={{ backgroundColor: printerColors.divider }} />
-
-            <View className="flex-row items-center gap-2.5">
-              <Icon name="checkmark-circle" size={20} color={COLORS.SUCCESS} />
-              <Text className="text-sm font-medium" style={{ color: printerColors.screenStatus }}>
-                Payment settled
-              </Text>
-            </View>
-          </View>
-        </View>
-
-        <View
-          accessibilityElementsHidden
-          className="-mt-7 z-40 h-[14px] w-[88%] self-center rounded-full border"
-          importantForAccessibility="no-hide-descendants"
-          style={{
-            backgroundColor: printerColors.slot,
-            borderColor: printerColors.slotBorder,
-            shadowColor: "#000000",
-            shadowOffset: { width: 0, height: 2 },
-            shadowOpacity: 0.7,
-            shadowRadius: 4,
-            elevation: 14,
-          }}
-        />
-
-        <View className="-mt-1 z-30 w-full items-center overflow-hidden pb-2">
-          <Animated.View
-            className="w-[80%] px-5 pt-7 pb-9"
-            style={[
-              {
-                backgroundColor: PAPER_COLOR,
-                shadowColor: "#000000",
-                shadowOffset: { width: 0, height: 12 },
-                shadowOpacity: 0.22,
-                shadowRadius: 18,
-                elevation: 9,
-              },
-              paperAnimatedStyle,
-            ]}
-          >
-            <View className="items-center">
-              <Image
-                accessibilityIgnoresInvertColors
-                accessible={false}
-                className="size-12 rounded-[14px]"
-                resizeMode="cover"
-                source={noahIcon}
-              />
-              <Text
-                className="mt-3 font-mono text-sm font-bold uppercase tracking-[3px]"
-                style={{ color: PAPER_INK }}
-              >
-                Payment receipt
-              </Text>
-              <Text className="mt-1 font-mono text-[10px]" style={{ color: PAPER_MUTED_INK }}>
-                {formatCompletedAt(completedAt)}
-              </Text>
-            </View>
-
-            <ReceiptDivider />
-
-            <View className="flex-row items-end justify-between gap-4">
-              <View>
-                <Text
-                  className="font-mono text-[10px] font-bold uppercase tracking-[2px]"
-                  style={{ color: PAPER_MUTED_INK }}
-                >
-                  Total paid
-                </Text>
-                {fiatAmount ? (
-                  <Text className="mt-1 font-mono text-xs" style={{ color: PAPER_MUTED_INK }}>
-                    ≈ {formatFiatAmount(fiatAmount, fiatCurrency)}
-                  </Text>
-                ) : null}
-              </View>
-              <Text className="font-mono text-xl font-bold" style={{ color: PAPER_INK }}>
-                {formatBitcoinAmount(parsedResult.amount_sat)}
-              </Text>
-            </View>
-
-            <ReceiptDivider />
-
-            <View className="flex-row items-center justify-between gap-4">
-              <Text className="font-mono text-xs" style={{ color: PAPER_MUTED_INK }}>
-                Payment route
-              </Text>
-              <Text className="font-mono text-xs font-bold" style={{ color: PAPER_INK }}>
-                {parsedResult.type}
-              </Text>
-            </View>
-
-            <View className="mt-3">
-              <ReceiptCopyRow
-                label="Paid to"
-                value={parsedResult.destination}
-                copyId="receipt-destination"
-              />
-              {proofValue ? (
-                <ReceiptCopyRow label={proofLabel} value={proofValue} copyId="receipt-proof" />
-              ) : null}
-            </View>
-
-            <ReceiptDivider />
-
-            <View className="items-center">
-              <Text
-                className="font-mono text-[10px] uppercase tracking-[2px]"
-                style={{ color: PAPER_MUTED_INK }}
-              >
-                Reference
-              </Text>
-              <Text
-                className="mt-1 font-mono text-xs font-bold uppercase tracking-[2.5px]"
-                style={{ color: PAPER_INK }}
-              >
-                {reference}
-              </Text>
-              <Text className="mt-4 font-mono text-[10px]" style={{ color: PAPER_MUTED_INK }}>
-                Thanks for sailing with Noah.
-              </Text>
-            </View>
-
-            <View
-              accessibilityElementsHidden
-              className="absolute right-0 -bottom-2 left-0 flex-row justify-around px-1"
-              importantForAccessibility="no-hide-descendants"
-            >
-              {PAPER_TEETH.map((tooth) => (
-                <View
-                  key={tooth}
-                  className="size-4 rotate-45"
-                  style={{ backgroundColor: PAPER_COLOR }}
-                />
-              ))}
-            </View>
-          </Animated.View>
-        </View>
-      </View>
-
-      <View className="mt-4 px-1">
-        <NativeNoahButton label="Done" onPress={handleDone} fullWidth />
       </View>
     </View>
   );

--- a/client/src/components/SendSuccessBottomSheet.tsx
+++ b/client/src/components/SendSuccessBottomSheet.tsx
@@ -19,6 +19,7 @@ import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
 import { formatFiatAmount, satsToFiat } from "~/lib/fiatCurrency";
 import { COLORS } from "~/lib/styleConstants";
 import { NativeNoahButton } from "./ui/NativeNoahButton";
+import { NativeNoahSecondaryButton } from "./ui/NativeNoahSecondaryButton";
 import { Text } from "./ui/text";
 import noahIcon from "../../assets/icon.png";
 
@@ -150,6 +151,7 @@ export const SendSuccessBottomSheet: React.FC<SendSuccessBottomSheetProps> = ({
   const { isDark } = useTheme();
   const shouldReduceMotion = useReducedMotion();
   const [completedAt] = useState(() => new Date());
+  const [showReceipt, setShowReceipt] = useState(false);
   const paperOffset = useSharedValue(shouldReduceMotion ? 0 : -PAPER_TRAVEL);
   const paperOpacity = useSharedValue(shouldReduceMotion ? 1 : 0);
   const fiatAmount = btcPrice ? satsToFiat(parsedResult.amount_sat, btcPrice, fiatCurrency) : null;
@@ -193,8 +195,67 @@ export const SendSuccessBottomSheet: React.FC<SendSuccessBottomSheetProps> = ({
     transform: [{ translateY: paperOffset.value }],
   }));
 
+  if (!showReceipt) {
+    return (
+      <View className="pb-2" testID="send-success-sheet">
+        <View className="items-center px-5 pt-8">
+          <View className="size-20 items-center justify-center rounded-full bg-success/15">
+            <Icon name="checkmark" size={48} color={COLORS.SUCCESS} />
+          </View>
+          <Text className="mt-7 text-center text-4xl font-bold text-foreground">Payment sent</Text>
+          <Text className="mt-3 text-center text-3xl font-semibold text-foreground">
+            {formatBitcoinAmount(parsedResult.amount_sat)}
+          </Text>
+          {fiatAmount ? (
+            <Text className="mt-2 text-base text-muted-foreground">
+              ≈ {formatFiatAmount(fiatAmount, fiatCurrency)}
+            </Text>
+          ) : null}
+
+          <View className="mt-8 w-full border-y border-border/70 py-4">
+            <View className="flex-row items-center justify-between gap-5">
+              <Text className="text-base text-muted-foreground">Paid via</Text>
+              <Text className="text-base font-semibold text-foreground">{parsedResult.type}</Text>
+            </View>
+            <View className="mt-4 flex-row items-start justify-between gap-5">
+              <Text className="text-base text-muted-foreground">To</Text>
+              <Text className="min-w-0 flex-1 text-right text-base font-semibold text-foreground">
+                {truncateValue(parsedResult.destination)}
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        <View className="mt-10 gap-3 px-1">
+          <NativeNoahSecondaryButton
+            label="View receipt"
+            onPress={() => setShowReceipt(true)}
+            size="lg"
+            fullWidth
+            testID="send-success-view-receipt"
+          />
+          <NativeNoahButton
+            label="Done"
+            onPress={handleDone}
+            size="lg"
+            fullWidth
+            testID="send-success-done"
+          />
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View className="pb-2" testID="send-success-receipt">
+      <View className="mb-4 px-1">
+        <NativeNoahSecondaryButton
+          label="Back to summary"
+          onPress={() => setShowReceipt(false)}
+          fullWidth
+          testID="send-success-back-to-summary"
+        />
+      </View>
       <View className="items-center px-1">
         <View
           className="z-20 w-full rounded-[30px] border px-4 pt-4 pb-12"

--- a/client/src/components/send/SendAmountStage.tsx
+++ b/client/src/components/send/SendAmountStage.tsx
@@ -1,11 +1,14 @@
 import Icon from "@react-native-vector-icons/ionicons";
+import * as Haptics from "expo-haptics";
 import { useState } from "react";
 import { Pressable, View } from "react-native";
 import { useBottomTabBarHeight } from "react-native-bottom-tabs";
+import Animated, { FadeIn, FadeOut, useReducedMotion } from "react-native-reanimated";
 
 import { AmountKeypad } from "~/components/AmountKeypad";
 import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
 import { NativeNoahBackButton } from "~/components/ui/NativeNoahIconButton";
+import { NativeNoahSecondaryButton } from "~/components/ui/NativeNoahSecondaryButton";
 import { Text } from "~/components/ui/text";
 import { useBitcoinAmountFormatter, useBitcoinAmountUnit } from "~/hooks/useBitcoinAmountFormatter";
 import { useThemeColors } from "~/hooks/useTheme";
@@ -25,10 +28,15 @@ type SendAmountStageProps = {
   error: string | null;
   isAmountEditable: boolean;
   canSendMax: boolean;
+  canClear: boolean;
+  recipient: string | null;
+  recipientLabel: string | null;
   onBack?: () => void;
   onAmountChange: (amount: string) => void;
   onToggleCurrency: () => void;
   onContinue: () => void;
+  onClear: () => void;
+  onEditRecipient: () => void;
   onMax: () => void;
   onPaste: () => void;
   onScan: () => void;
@@ -45,15 +53,21 @@ export function SendAmountStage({
   error,
   isAmountEditable,
   canSendMax,
+  canClear,
+  recipient,
+  recipientLabel,
   onBack,
   onAmountChange,
   onToggleCurrency,
   onContinue,
+  onClear,
+  onEditRecipient,
   onMax,
   onPaste,
   onScan,
 }: SendAmountStageProps) {
   const colors = useThemeColors();
+  const shouldReduceMotion = useReducedMotion();
   const formatBitcoinAmount = useBitcoinAmountFormatter();
   const bitcoinAmountUnit = useBitcoinAmountUnit();
   const bottomTabBarHeight = useBottomTabBarHeight();
@@ -73,6 +87,10 @@ export function SendAmountStage({
         : `${fiatCurrencyInfo.code} rate unavailable`
       : formatBitcoinAmount(amountSat);
   const canContinue = Number.isInteger(amountSat) && amountSat > 0;
+  const handleClear = () => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onClear();
+  };
 
   return (
     <View className="flex-1 px-5" testID="send-amount-stage">
@@ -173,32 +191,84 @@ export function SendAmountStage({
           />
         </Pressable>
 
-        <View className="mt-3 flex-row items-center gap-3">
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Send maximum amount"
-            onPress={onMax}
-            disabled={!canSendMax}
-            accessibilityState={{ disabled: !canSendMax }}
-            className="h-12 min-w-[88px] items-center justify-center rounded-full border px-6"
-            testID="send-max"
-            style={{
-              borderColor: `${COLORS.BITCOIN_ORANGE}88`,
-              opacity: canSendMax ? 1 : 0.45,
-            }}
+        {recipient && recipientLabel ? (
+          <Animated.View
+            entering={FadeIn.duration(shouldReduceMotion ? 100 : 180)}
+            exiting={FadeOut.duration(shouldReduceMotion ? 80 : 120)}
+            className="mt-3 w-full max-w-[370px] flex-row items-center rounded-2xl border border-border/70 bg-card px-4 py-3"
+            testID="send-amount-recipient"
           >
-            <Text className="text-sm font-bold tracking-[1.5px] text-foreground">MAX</Text>
-          </Pressable>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Paste payment request"
-            onPress={onPaste}
-            className="h-12 min-w-[88px] items-center justify-center rounded-full border border-border px-6"
-            testID="send-paste-from-amount"
+            <View className="min-w-0 flex-1">
+              <Text className="text-xs font-medium uppercase tracking-[1.2px] text-muted-foreground">
+                To · {recipientLabel}
+              </Text>
+              <Text
+                className="mt-1 text-sm font-semibold text-foreground"
+                ellipsizeMode="middle"
+                numberOfLines={1}
+                testID="send-amount-recipient-value"
+              >
+                {recipient}
+              </Text>
+            </View>
+            <View className="ml-3 flex-row items-center gap-1">
+              {canSendMax ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Send maximum amount"
+                  onPress={onMax}
+                  className="h-10 items-center justify-center rounded-full px-3"
+                  testID="send-max"
+                  style={{ backgroundColor: `${COLORS.BITCOIN_ORANGE}14` }}
+                >
+                  <Text className="text-xs font-bold tracking-[1.2px] text-foreground">MAX</Text>
+                </Pressable>
+              ) : null}
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Change recipient"
+                onPress={onEditRecipient}
+                className="h-10 items-center justify-center rounded-full px-3"
+                testID="send-amount-change-recipient"
+              >
+                <Text className="text-sm font-semibold" style={{ color: COLORS.BITCOIN_ORANGE }}>
+                  Change
+                </Text>
+              </Pressable>
+            </View>
+          </Animated.View>
+        ) : (
+          <Animated.View
+            entering={FadeIn.duration(shouldReduceMotion ? 100 : 180)}
+            exiting={FadeOut.duration(shouldReduceMotion ? 80 : 120)}
+            className="mt-3 flex-row items-center gap-3"
           >
-            <Text className="text-sm font-semibold text-foreground">Paste</Text>
-          </Pressable>
-        </View>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Send maximum amount"
+              onPress={onMax}
+              disabled={!canSendMax}
+              accessibilityState={{ disabled: !canSendMax }}
+              className="h-12 min-w-[88px] items-center justify-center rounded-full border px-6"
+              testID="send-max"
+              style={{
+                borderColor: `${COLORS.BITCOIN_ORANGE}88`,
+                opacity: canSendMax ? 1 : 0.45,
+              }}
+            >
+              <Text className="text-sm font-bold tracking-[1.5px] text-foreground">MAX</Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Paste payment request"
+              onPress={onPaste}
+              className="h-12 min-w-[88px] items-center justify-center rounded-full border border-border px-6"
+              testID="send-paste-from-amount"
+            >
+              <Text className="text-sm font-semibold text-foreground">Paste</Text>
+            </Pressable>
+          </Animated.View>
+        )}
 
         {error ? (
           <Text className="mt-3 text-center text-sm text-destructive" testID="send-amount-error">
@@ -225,14 +295,29 @@ export function SendAmountStage({
       )}
 
       <View style={{ paddingBottom: Math.max(bottomTabBarHeight, 20) + 8 }}>
-        <NativeNoahButton
-          label="Next"
-          onPress={onContinue}
-          disabled={!canContinue}
-          size="lg"
-          fullWidth
-          testID="send-amount-next"
-        />
+        <View className="flex-row gap-3">
+          <View className="flex-1">
+            <NativeNoahSecondaryButton
+              label="Clear"
+              onPress={handleClear}
+              disabled={!canClear}
+              size="lg"
+              tone="neutral"
+              fullWidth
+              testID="send-amount-clear"
+            />
+          </View>
+          <View className="flex-[2]">
+            <NativeNoahButton
+              label="Next"
+              onPress={onContinue}
+              disabled={!canContinue}
+              size="lg"
+              fullWidth
+              testID="send-amount-next"
+            />
+          </View>
+        </View>
       </View>
     </View>
   );

--- a/client/src/components/send/SendAmountStage.tsx
+++ b/client/src/components/send/SendAmountStage.tsx
@@ -213,9 +213,7 @@ export function SendAmountStage({
           <Text className="text-sm font-semibold text-foreground">
             Amount set by payment request
           </Text>
-          <Text className="mt-1 text-sm text-muted-foreground">
-            Go back to change the recipient.
-          </Text>
+          <Text className="mt-1 text-sm text-muted-foreground">This amount cannot be edited.</Text>
         </View>
       )}
 

--- a/client/src/components/send/SendAmountStage.tsx
+++ b/client/src/components/send/SendAmountStage.tsx
@@ -22,6 +22,8 @@ type SendAmountStageProps = {
   arkBalanceSat: number;
   onchainBalanceSat: number;
   error: string | null;
+  isAmountEditable: boolean;
+  canSendMax: boolean;
   onAmountChange: (amount: string) => void;
   onToggleCurrency: () => void;
   onContinue: () => void;
@@ -39,6 +41,8 @@ export function SendAmountStage({
   arkBalanceSat,
   onchainBalanceSat,
   error,
+  isAmountEditable,
+  canSendMax,
   onAmountChange,
   onToggleCurrency,
   onContinue,
@@ -167,9 +171,14 @@ export function SendAmountStage({
             accessibilityRole="button"
             accessibilityLabel="Send maximum amount"
             onPress={onMax}
+            disabled={!canSendMax}
+            accessibilityState={{ disabled: !canSendMax }}
             className="rounded-full border px-4 py-2"
-            style={{ borderColor: `${COLORS.BITCOIN_ORANGE}88` }}
             testID="send-max"
+            style={{
+              borderColor: `${COLORS.BITCOIN_ORANGE}88`,
+              opacity: canSendMax ? 1 : 0.45,
+            }}
           >
             <Text className="text-xs font-bold tracking-[2px] text-foreground">MAX</Text>
           </Pressable>
@@ -191,13 +200,24 @@ export function SendAmountStage({
         ) : null}
       </View>
 
-      <AmountKeypad
-        amount={amount}
-        currency={currency}
-        fiatDecimals={fiatCurrencyInfo.decimals}
-        onChange={onAmountChange}
-        testIDPrefix="send-key"
-      />
+      {isAmountEditable ? (
+        <AmountKeypad
+          amount={amount}
+          currency={currency}
+          fiatDecimals={fiatCurrencyInfo.decimals}
+          onChange={onAmountChange}
+          testIDPrefix="send-key"
+        />
+      ) : (
+        <View className="mb-6 items-center border-y border-border/60 py-5">
+          <Text className="text-sm font-semibold text-foreground">
+            Amount set by payment request
+          </Text>
+          <Text className="mt-1 text-sm text-muted-foreground">
+            Go back to change the recipient.
+          </Text>
+        </View>
+      )}
 
       <View style={{ paddingBottom: Math.max(bottomTabBarHeight, 20) + 8 }}>
         <NativeNoahButton

--- a/client/src/components/send/SendAmountStage.tsx
+++ b/client/src/components/send/SendAmountStage.tsx
@@ -1,0 +1,214 @@
+import Icon from "@react-native-vector-icons/ionicons";
+import { useState } from "react";
+import { Pressable, View } from "react-native";
+import { useBottomTabBarHeight } from "react-native-bottom-tabs";
+
+import { AmountKeypad } from "~/components/AmountKeypad";
+import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
+import { Text } from "~/components/ui/text";
+import { useBitcoinAmountFormatter, useBitcoinAmountUnit } from "~/hooks/useBitcoinAmountFormatter";
+import { useThemeColors } from "~/hooks/useTheme";
+import { formatFiatAmount, getFiatCurrencyInfo, satsToFiat } from "~/lib/fiatCurrency";
+import type { FiatCurrencyCode } from "~/lib/fiatCurrency";
+import { COLORS } from "~/lib/styleConstants";
+import { formatNumber } from "~/lib/utils";
+
+type SendAmountStageProps = {
+  amount: string;
+  amountSat: number;
+  currency: "FIAT" | "SATS";
+  fiatCurrency: FiatCurrencyCode;
+  btcPrice?: number;
+  arkBalanceSat: number;
+  onchainBalanceSat: number;
+  error: string | null;
+  onAmountChange: (amount: string) => void;
+  onToggleCurrency: () => void;
+  onContinue: () => void;
+  onMax: () => void;
+  onPaste: () => void;
+  onScan: () => void;
+};
+
+export function SendAmountStage({
+  amount,
+  amountSat,
+  currency,
+  fiatCurrency,
+  btcPrice,
+  arkBalanceSat,
+  onchainBalanceSat,
+  error,
+  onAmountChange,
+  onToggleCurrency,
+  onContinue,
+  onMax,
+  onPaste,
+  onScan,
+}: SendAmountStageProps) {
+  const colors = useThemeColors();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
+  const bitcoinAmountUnit = useBitcoinAmountUnit();
+  const bottomTabBarHeight = useBottomTabBarHeight();
+  const fiatCurrencyInfo = getFiatCurrencyInfo(fiatCurrency);
+  const [showBalances, setShowBalances] = useState(false);
+  const displayAmount = amount.length === 0 ? "0" : formatNumber(amount);
+  const amountPrefix =
+    currency === "FIAT" ? fiatCurrencyInfo.symbol : bitcoinAmountUnit === "bip177" ? "₿" : null;
+  const primaryAmount = amountPrefix ? `${amountPrefix}${displayAmount}` : displayAmount;
+  const primaryAmountFontSize =
+    primaryAmount.length <= 7 ? 64 : primaryAmount.length <= 10 ? 50 : 38;
+  const amountSuffix = currency === "SATS" && bitcoinAmountUnit === "sats" ? "sats" : null;
+  const convertedAmount =
+    currency === "SATS"
+      ? btcPrice
+        ? formatFiatAmount(satsToFiat(amountSat, btcPrice, fiatCurrency), fiatCurrency)
+        : `${fiatCurrencyInfo.code} rate unavailable`
+      : formatBitcoinAmount(amountSat);
+  const canContinue = Number.isInteger(amountSat) && amountSat > 0;
+
+  return (
+    <View className="flex-1 px-5" testID="send-amount-stage">
+      <View className="flex-row items-center justify-between pt-4">
+        <View className="w-12" />
+        <View className="items-center">
+          <Text accessibilityRole="header" className="text-xl font-bold text-foreground">
+            Send bitcoin
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Show wallet balances"
+            onPress={() => setShowBalances((visible) => !visible)}
+            className="mt-1 px-3 py-1"
+            testID="send-balance-details"
+          >
+            <Text className="text-sm text-muted-foreground">
+              {formatBitcoinAmount(arkBalanceSat)} available
+            </Text>
+          </Pressable>
+        </View>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Scan payment request"
+          onPress={onScan}
+          className="h-12 w-12 items-center justify-center rounded-full border border-border bg-card"
+          testID="send-scan"
+        >
+          <Icon name="scan" size={23} color={colors.foreground} />
+        </Pressable>
+      </View>
+
+      {showBalances ? (
+        <View className="mt-4 border-y border-border/60 py-3" testID="send-balance-breakdown">
+          <View className="flex-row items-center justify-between">
+            <Text className="text-sm text-muted-foreground">Ark balance</Text>
+            <Text className="text-sm font-semibold text-foreground">
+              {formatBitcoinAmount(arkBalanceSat)}
+            </Text>
+          </View>
+          <View className="mt-2 flex-row items-center justify-between">
+            <Text className="text-sm text-muted-foreground">On-chain wallet</Text>
+            <Text className="text-sm font-semibold text-foreground">
+              {formatBitcoinAmount(onchainBalanceSat)}
+            </Text>
+          </View>
+        </View>
+      ) : null}
+
+      <View className="flex-1 items-center justify-center py-3">
+        <View
+          accessibilityRole="text"
+          accessibilityLabel={`${amount.length === 0 ? "0" : amount} ${
+            currency === "SATS" ? "sats" : fiatCurrency
+          }`}
+          className="flex-row items-baseline justify-center px-2"
+        >
+          <Text
+            className="text-center font-bold text-foreground"
+            numberOfLines={1}
+            style={{
+              maxWidth: amountSuffix ? 280 : 340,
+              fontSize: primaryAmountFontSize,
+              lineHeight: primaryAmountFontSize + 8,
+            }}
+            testID="send-amount-value"
+          >
+            {primaryAmount}
+          </Text>
+          {amountSuffix ? (
+            <Text className="ml-2 text-xl font-semibold text-muted-foreground">{amountSuffix}</Text>
+          ) : null}
+        </View>
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Switch to ${currency === "SATS" ? fiatCurrency : "sats"}`}
+          accessibilityState={{ disabled: !btcPrice }}
+          disabled={!btcPrice}
+          onPress={onToggleCurrency}
+          className="mt-2 flex-row items-center gap-2 px-4 py-2"
+          testID="send-currency-toggle"
+        >
+          <Text
+            className="text-xl font-semibold leading-7"
+            style={{ color: btcPrice ? COLORS.SUCCESS : colors.mutedForeground }}
+          >
+            {convertedAmount}
+          </Text>
+          <Icon
+            name="swap-vertical"
+            size={21}
+            color={btcPrice ? COLORS.SUCCESS : colors.mutedForeground}
+          />
+        </Pressable>
+
+        <View className="mt-3 flex-row items-center gap-3">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Send maximum amount"
+            onPress={onMax}
+            className="rounded-full border px-4 py-2"
+            style={{ borderColor: `${COLORS.BITCOIN_ORANGE}88` }}
+            testID="send-max"
+          >
+            <Text className="text-xs font-bold tracking-[2px] text-foreground">MAX</Text>
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Paste payment request"
+            onPress={onPaste}
+            className="rounded-full border border-border px-4 py-2"
+            testID="send-paste-from-amount"
+          >
+            <Text className="text-sm font-semibold text-foreground">Paste</Text>
+          </Pressable>
+        </View>
+
+        {error ? (
+          <Text className="mt-3 text-center text-sm text-destructive" testID="send-amount-error">
+            {error}
+          </Text>
+        ) : null}
+      </View>
+
+      <AmountKeypad
+        amount={amount}
+        currency={currency}
+        fiatDecimals={fiatCurrencyInfo.decimals}
+        onChange={onAmountChange}
+        testIDPrefix="send-key"
+      />
+
+      <View style={{ paddingBottom: Math.max(bottomTabBarHeight, 20) + 8 }}>
+        <NativeNoahButton
+          label="Next"
+          onPress={onContinue}
+          disabled={!canContinue}
+          size="lg"
+          fullWidth
+          testID="send-amount-next"
+        />
+      </View>
+    </View>
+  );
+}

--- a/client/src/components/send/SendAmountStage.tsx
+++ b/client/src/components/send/SendAmountStage.tsx
@@ -81,7 +81,7 @@ export function SendAmountStage({
           </Text>
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel="Show wallet balances"
+            accessibilityLabel={`Show wallet balances, ${formatBitcoinAmount(arkBalanceSat)} available`}
             onPress={() => setShowBalances((visible) => !visible)}
             className="mt-1 px-3 py-1"
             testID="send-balance-details"

--- a/client/src/components/send/SendAmountStage.tsx
+++ b/client/src/components/send/SendAmountStage.tsx
@@ -5,6 +5,7 @@ import { useBottomTabBarHeight } from "react-native-bottom-tabs";
 
 import { AmountKeypad } from "~/components/AmountKeypad";
 import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
+import { NativeNoahBackButton } from "~/components/ui/NativeNoahIconButton";
 import { Text } from "~/components/ui/text";
 import { useBitcoinAmountFormatter, useBitcoinAmountUnit } from "~/hooks/useBitcoinAmountFormatter";
 import { useThemeColors } from "~/hooks/useTheme";
@@ -24,6 +25,7 @@ type SendAmountStageProps = {
   error: string | null;
   isAmountEditable: boolean;
   canSendMax: boolean;
+  onBack?: () => void;
   onAmountChange: (amount: string) => void;
   onToggleCurrency: () => void;
   onContinue: () => void;
@@ -43,6 +45,7 @@ export function SendAmountStage({
   error,
   isAmountEditable,
   canSendMax,
+  onBack,
   onAmountChange,
   onToggleCurrency,
   onContinue,
@@ -74,7 +77,11 @@ export function SendAmountStage({
   return (
     <View className="flex-1 px-5" testID="send-amount-stage">
       <View className="flex-row items-center justify-between pt-4">
-        <View className="w-12" />
+        {onBack ? (
+          <NativeNoahBackButton onPress={onBack} testID="send-amount-back" />
+        ) : (
+          <View className="w-12" />
+        )}
         <View className="items-center">
           <Text accessibilityRole="header" className="text-xl font-bold text-foreground">
             Send bitcoin

--- a/client/src/components/send/SendAmountStage.tsx
+++ b/client/src/components/send/SendAmountStage.tsx
@@ -180,20 +180,20 @@ export function SendAmountStage({
             onPress={onMax}
             disabled={!canSendMax}
             accessibilityState={{ disabled: !canSendMax }}
-            className="rounded-full border px-4 py-2"
+            className="h-12 min-w-[88px] items-center justify-center rounded-full border px-6"
             testID="send-max"
             style={{
               borderColor: `${COLORS.BITCOIN_ORANGE}88`,
               opacity: canSendMax ? 1 : 0.45,
             }}
           >
-            <Text className="text-xs font-bold tracking-[2px] text-foreground">MAX</Text>
+            <Text className="text-sm font-bold tracking-[1.5px] text-foreground">MAX</Text>
           </Pressable>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Paste payment request"
             onPress={onPaste}
-            className="rounded-full border border-border px-4 py-2"
+            className="h-12 min-w-[88px] items-center justify-center rounded-full border border-border px-6"
             testID="send-paste-from-amount"
           >
             <Text className="text-sm font-semibold text-foreground">Paste</Text>

--- a/client/src/components/send/SendChoiceStage.tsx
+++ b/client/src/components/send/SendChoiceStage.tsx
@@ -1,0 +1,130 @@
+import Icon from "@react-native-vector-icons/ionicons";
+import { Pressable, View } from "react-native";
+import { useBottomTabBarHeight } from "react-native-bottom-tabs";
+
+import { NativeNoahBackButton } from "~/components/ui/NativeNoahIconButton";
+import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
+import { Text } from "~/components/ui/text";
+import { useThemeColors } from "~/hooks/useTheme";
+import { COLORS } from "~/lib/styleConstants";
+
+export type SendChoiceOption<T extends string> = {
+  value: T;
+  title: string;
+  subtitle: string;
+  detail?: string;
+  unavailableReason?: string;
+};
+
+type SendChoiceStageProps<T extends string> = {
+  title: string;
+  description: string;
+  options: readonly SendChoiceOption<T>[];
+  value: T | null;
+  onBack: () => void;
+  onChange: (value: T) => void;
+  onContinue: () => void;
+  testIDPrefix: string;
+};
+
+export function SendChoiceStage<T extends string>({
+  title,
+  description,
+  options,
+  value,
+  onBack,
+  onChange,
+  onContinue,
+  testIDPrefix,
+}: SendChoiceStageProps<T>) {
+  const colors = useThemeColors();
+  const bottomTabBarHeight = useBottomTabBarHeight();
+  const selectedOption = options.find((option) => option.value === value);
+  const canContinue = selectedOption !== undefined && !selectedOption.unavailableReason;
+
+  return (
+    <View className="flex-1 px-5" testID={`${testIDPrefix}-stage`}>
+      <View className="flex-row items-center pt-4">
+        <NativeNoahBackButton onPress={onBack} testID={`${testIDPrefix}-back`} />
+      </View>
+
+      <View className="mt-8">
+        <Text accessibilityRole="header" className="text-3xl font-bold text-foreground">
+          {title}
+        </Text>
+        <Text className="mt-2 max-w-[330px] text-base leading-6 text-muted-foreground">
+          {description}
+        </Text>
+      </View>
+
+      <View className="mt-9 flex-1">
+        {options.map((option, index) => {
+          const isSelected = option.value === value;
+          const isUnavailable = option.unavailableReason !== undefined;
+
+          return (
+            <Pressable
+              key={option.value}
+              accessibilityRole="radio"
+              accessibilityLabel={`${option.title}. ${option.subtitle}`}
+              accessibilityState={{ checked: isSelected, disabled: isUnavailable }}
+              disabled={isUnavailable}
+              onPress={() => onChange(option.value)}
+              className={`flex-row items-center gap-4 py-5 ${
+                index < options.length - 1 ? "border-b border-border/60" : ""
+              }`}
+              testID={`${testIDPrefix}-${option.value}`}
+              style={{ opacity: isUnavailable ? 0.55 : 1 }}
+            >
+              <View className="min-w-0 flex-1">
+                <View className="flex-row items-center gap-2">
+                  <Text className="text-lg font-semibold text-foreground">{option.title}</Text>
+                  {isSelected ? (
+                    <View
+                      className="rounded-full px-2 py-0.5"
+                      style={{ backgroundColor: `${COLORS.BITCOIN_ORANGE}1F` }}
+                    >
+                      <Text
+                        className="text-[10px] font-bold uppercase tracking-[1.4px]"
+                        style={{ color: COLORS.BITCOIN_ORANGE }}
+                      >
+                        Selected
+                      </Text>
+                    </View>
+                  ) : null}
+                </View>
+                <Text className="mt-1 text-sm leading-5 text-muted-foreground">
+                  {option.subtitle}
+                </Text>
+                {option.detail ? (
+                  <Text className="mt-2 text-sm font-semibold text-foreground">
+                    {option.detail}
+                  </Text>
+                ) : null}
+                {option.unavailableReason ? (
+                  <Text className="mt-2 text-sm text-destructive">{option.unavailableReason}</Text>
+                ) : null}
+              </View>
+              <Icon
+                name={isSelected ? "checkmark-circle" : "ellipse-outline"}
+                size={26}
+                color={isSelected ? COLORS.BITCOIN_ORANGE : colors.mutedForeground}
+              />
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <View style={{ paddingBottom: Math.max(bottomTabBarHeight, 20) + 8 }}>
+        <NativeNoahButton
+          label="Continue"
+          onPress={onContinue}
+          disabled={!canContinue}
+          size="lg"
+          fullWidth
+          testID={`${testIDPrefix}-next`}
+        />
+      </View>
+    </View>
+  );
+}

--- a/client/src/components/send/SendRecipientStage.tsx
+++ b/client/src/components/send/SendRecipientStage.tsx
@@ -1,0 +1,281 @@
+import Icon from "@react-native-vector-icons/ionicons";
+import { useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  TextInput,
+  View,
+} from "react-native";
+import { useBottomTabBarHeight } from "react-native-bottom-tabs";
+
+import { NativeNoahBackButton } from "~/components/ui/NativeNoahIconButton";
+import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
+import { Text } from "~/components/ui/text";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
+import { useThemeColors } from "~/hooks/useTheme";
+import { getBip321Rails } from "~/lib/sendFlow";
+import type { DestinationTypes, ParsedBip321 } from "~/lib/sendUtils";
+import { COLORS } from "~/lib/styleConstants";
+
+type SendRecipientStageProps = {
+  amountSat: number;
+  destination: string;
+  destinationType: DestinationTypes;
+  bip321Data: ParsedBip321 | null;
+  suggestions: string[];
+  error: string | null;
+  comment: string;
+  commentAllowed: number;
+  noteUsesLightning: boolean;
+  isResolving: boolean;
+  onBack: () => void;
+  onDestinationChange: (destination: string) => void;
+  onSelectSuggestion: (suggestion: string) => void;
+  onCommentChange: (comment: string) => void;
+  onPaste: () => void;
+  onScan: () => void;
+  onContinue: () => void;
+};
+
+const getDestinationLabel = (destinationType: DestinationTypes) => {
+  switch (destinationType) {
+    case "ark":
+      return "Ark address";
+    case "lightning":
+      return "Lightning invoice";
+    case "offer":
+      return "Lightning offer";
+    case "lnurl":
+      return "Lightning address";
+    case "onchain":
+      return "On-chain address";
+    case "bip321":
+      return "Bitcoin payment request";
+    default:
+      return null;
+  }
+};
+
+export function SendRecipientStage({
+  amountSat,
+  destination,
+  destinationType,
+  bip321Data,
+  suggestions,
+  error,
+  comment,
+  commentAllowed,
+  noteUsesLightning,
+  isResolving,
+  onBack,
+  onDestinationChange,
+  onSelectSuggestion,
+  onCommentChange,
+  onPaste,
+  onScan,
+  onContinue,
+}: SendRecipientStageProps) {
+  const colors = useThemeColors();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
+  const bottomTabBarHeight = useBottomTabBarHeight();
+  const [isEditingNote, setIsEditingNote] = useState(comment.length > 0);
+  const destinationLabel = getDestinationLabel(destinationType);
+  const railSummary =
+    destinationType === "bip321" && bip321Data
+      ? getBip321Rails(bip321Data)
+          .map((rail) =>
+            rail === "onchain" ? "On-chain" : `${rail[0].toUpperCase()}${rail.slice(1)}`,
+          )
+          .join(" · ")
+      : destinationLabel;
+  const canContinue = destinationType !== null && !error && !isResolving;
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      className="flex-1"
+      keyboardVerticalOffset={8}
+      testID="send-recipient-stage"
+    >
+      <View className="flex-row items-center justify-between px-5 pt-4">
+        <NativeNoahBackButton onPress={onBack} testID="send-recipient-back" />
+        <View className="items-center">
+          <Text className="text-xl font-bold text-foreground">Recipient</Text>
+          {amountSat > 0 ? (
+            <Text className="mt-1 text-sm text-muted-foreground">
+              {formatBitcoinAmount(amountSat)}
+            </Text>
+          ) : null}
+        </View>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Scan payment request"
+          onPress={onScan}
+          className="h-11 w-11 items-center justify-center rounded-full border border-border bg-card"
+          testID="send-recipient-scan"
+        >
+          <Icon name="scan" size={22} color={colors.foreground} />
+        </Pressable>
+      </View>
+
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ paddingHorizontal: 20, paddingTop: 36, paddingBottom: 24 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text accessibilityRole="header" className="text-3xl font-bold text-foreground">
+          Who are you paying?
+        </Text>
+        <Text className="mt-2 text-base leading-6 text-muted-foreground">
+          Enter a Bitcoin, Lightning, or Ark destination.
+        </Text>
+
+        <View
+          className="mt-8 rounded-[22px] border px-4 py-3"
+          style={{
+            borderColor: error ? "#dc2626" : `${colors.mutedForeground}38`,
+            backgroundColor: colors.card,
+          }}
+        >
+          <View className="flex-row items-center gap-3">
+            <TextInput
+              accessibilityLabel="Payment recipient"
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoFocus
+              className="min-h-11 flex-1 text-base text-foreground"
+              keyboardType="email-address"
+              onChangeText={onDestinationChange}
+              placeholder="Address, invoice, offer, or name@domain"
+              placeholderTextColor={colors.mutedForeground}
+              testID="send-recipient-input"
+              value={destination}
+            />
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Paste payment request"
+              onPress={onPaste}
+              className="rounded-full px-3 py-2"
+              style={{ backgroundColor: `${colors.foreground}0D` }}
+              testID="send-recipient-paste"
+            >
+              <Text className="text-sm font-semibold text-foreground">Paste</Text>
+            </Pressable>
+          </View>
+        </View>
+
+        {error ? (
+          <Text
+            className="mt-2 px-1 text-sm leading-5 text-destructive"
+            testID="send-recipient-error"
+          >
+            {error}
+          </Text>
+        ) : null}
+
+        {suggestions.length > 0 ? (
+          <View className="mt-4 border-y border-border/60">
+            {suggestions.map((suggestion) => (
+              <Pressable
+                key={suggestion}
+                accessibilityRole="button"
+                onPress={() => onSelectSuggestion(suggestion)}
+                className="flex-row items-center gap-3 border-b border-border/60 py-4 last:border-b-0"
+              >
+                <View
+                  className="h-10 w-10 items-center justify-center rounded-full"
+                  style={{ backgroundColor: `${COLORS.BITCOIN_ORANGE}18` }}
+                >
+                  <Icon name="flash-outline" size={18} color={COLORS.BITCOIN_ORANGE} />
+                </View>
+                <Text className="min-w-0 flex-1 text-base font-semibold text-foreground">
+                  {suggestion}
+                </Text>
+                <Icon name="chevron-forward" size={18} color={colors.mutedForeground} />
+              </Pressable>
+            ))}
+          </View>
+        ) : null}
+
+        {destinationLabel ? (
+          <View className="mt-5 flex-row items-center gap-4 border-y border-border/60 py-4">
+            <View
+              className="h-12 w-12 items-center justify-center rounded-full"
+              style={{ backgroundColor: `${COLORS.BITCOIN_ORANGE}1A` }}
+            >
+              <Icon
+                name={destinationType === "onchain" ? "logo-bitcoin" : "flash-outline"}
+                size={23}
+                color={COLORS.BITCOIN_ORANGE}
+              />
+            </View>
+            <View className="min-w-0 flex-1">
+              <Text className="text-base font-semibold text-foreground">{destinationLabel}</Text>
+              {railSummary ? (
+                <Text className="mt-1 text-sm text-muted-foreground">{railSummary}</Text>
+              ) : null}
+            </View>
+            <Icon name="checkmark-circle" size={24} color={COLORS.SUCCESS} />
+          </View>
+        ) : null}
+
+        {commentAllowed > 0 ? (
+          <View className="mt-5">
+            {isEditingNote ? (
+              <>
+                <TextInput
+                  accessibilityLabel="Payment note"
+                  className="rounded-2xl border border-border bg-card px-4 py-4 text-base text-foreground"
+                  maxLength={commentAllowed}
+                  onChangeText={onCommentChange}
+                  placeholder="Add a note"
+                  placeholderTextColor={colors.mutedForeground}
+                  testID="send-note-input"
+                  value={comment}
+                />
+                <Text className="mt-2 text-right text-xs text-muted-foreground">
+                  {comment.length}/{commentAllowed}
+                </Text>
+              </>
+            ) : (
+              <Pressable
+                accessibilityRole="button"
+                onPress={() => setIsEditingNote(true)}
+                className="self-start px-1 py-2"
+                testID="send-add-note"
+              >
+                <Text className="font-semibold" style={{ color: COLORS.BITCOIN_ORANGE }}>
+                  Add a note
+                </Text>
+              </Pressable>
+            )}
+
+            {noteUsesLightning ? (
+              <Text className="mt-2 text-sm leading-5 text-muted-foreground">
+                Adding a note will send this payment over Lightning.
+              </Text>
+            ) : null}
+          </View>
+        ) : null}
+      </ScrollView>
+
+      <View
+        className="border-t border-border/50 bg-background px-5 pt-4"
+        style={{ paddingBottom: Math.max(bottomTabBarHeight, 20) + 8 }}
+      >
+        <NativeNoahButton
+          label="Continue"
+          loadingLabel="Checking recipient…"
+          onPress={onContinue}
+          disabled={!canContinue}
+          isLoading={isResolving}
+          size="lg"
+          fullWidth
+          testID="send-recipient-next"
+        />
+      </View>
+    </KeyboardAvoidingView>
+  );
+}

--- a/client/src/components/send/SendRecipientStage.tsx
+++ b/client/src/components/send/SendRecipientStage.tsx
@@ -15,7 +15,12 @@ import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
 import { Text } from "~/components/ui/text";
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 import { useThemeColors } from "~/hooks/useTheme";
-import { canAddRecipientNote, getBip321Rails, getSendRailLabel } from "~/lib/sendFlow";
+import {
+  canAddRecipientNote,
+  getBip321Rails,
+  getDestinationLabel,
+  getSendRailLabel,
+} from "~/lib/sendFlow";
 import type { DestinationTypes, ParsedBip321 } from "~/lib/sendUtils";
 import { COLORS } from "~/lib/styleConstants";
 
@@ -37,25 +42,6 @@ type SendRecipientStageProps = {
   onPaste: () => void;
   onScan: () => void;
   onContinue: () => void;
-};
-
-const getDestinationLabel = (destinationType: DestinationTypes) => {
-  switch (destinationType) {
-    case "ark":
-      return "Ark address";
-    case "lightning":
-      return "Lightning invoice";
-    case "offer":
-      return "Lightning offer";
-    case "lnurl":
-      return "Lightning address";
-    case "onchain":
-      return "On-chain address";
-    case "bip321":
-      return "Bitcoin payment request";
-    default:
-      return null;
-  }
 };
 
 export function SendRecipientStage({

--- a/client/src/components/send/SendRecipientStage.tsx
+++ b/client/src/components/send/SendRecipientStage.tsx
@@ -15,7 +15,7 @@ import { NativeNoahButton } from "~/components/ui/NativeNoahButton";
 import { Text } from "~/components/ui/text";
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 import { useThemeColors } from "~/hooks/useTheme";
-import { getBip321Rails } from "~/lib/sendFlow";
+import { canAddRecipientNote, getBip321Rails, getSendRailLabel } from "~/lib/sendFlow";
 import type { DestinationTypes, ParsedBip321 } from "~/lib/sendUtils";
 import { COLORS } from "~/lib/styleConstants";
 
@@ -84,12 +84,9 @@ export function SendRecipientStage({
   const destinationLabel = getDestinationLabel(destinationType);
   const railSummary =
     destinationType === "bip321" && bip321Data
-      ? getBip321Rails(bip321Data)
-          .map((rail) =>
-            rail === "onchain" ? "On-chain" : `${rail[0].toUpperCase()}${rail.slice(1)}`,
-          )
-          .join(" · ")
+      ? getBip321Rails(bip321Data).map(getSendRailLabel).join(" · ")
       : destinationLabel;
+  const canAddNote = canAddRecipientNote(destinationType, commentAllowed);
   const canContinue = destinationType !== null && !error && !isResolving;
 
   return (
@@ -221,7 +218,7 @@ export function SendRecipientStage({
           </View>
         ) : null}
 
-        {commentAllowed > 0 ? (
+        {canAddNote ? (
           <View className="mt-5">
             {isEditingNote ? (
               <>

--- a/client/src/components/send/SendStageTransition.tsx
+++ b/client/src/components/send/SendStageTransition.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+import { View } from "react-native";
+import Animated, {
+  Easing,
+  FadeIn,
+  FadeOut,
+  SlideInLeft,
+  SlideInRight,
+  useReducedMotion,
+} from "react-native-reanimated";
+
+import type { SendStage } from "~/lib/sendFlow";
+
+type SendStageTransitionProps = {
+  children: ReactNode;
+  direction: "back" | "forward";
+  stage: SendStage;
+};
+
+const TRANSITION_DURATION_MS = 240;
+const REDUCED_MOTION_DURATION_MS = 140;
+
+export function SendStageTransition({
+  children,
+  direction,
+  stage,
+}: SendStageTransitionProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const entering = shouldReduceMotion
+    ? FadeIn.duration(REDUCED_MOTION_DURATION_MS)
+    : (direction === "forward" ? SlideInRight : SlideInLeft)
+        .duration(TRANSITION_DURATION_MS)
+        .easing(Easing.out(Easing.cubic));
+
+  return (
+    <View className="flex-1 overflow-hidden" testID="send-stage-transition">
+      <Animated.View
+        key={stage}
+        className="absolute inset-0"
+        entering={entering}
+        exiting={FadeOut.duration(shouldReduceMotion ? REDUCED_MOTION_DURATION_MS : 120)}
+      >
+        {children}
+      </Animated.View>
+    </View>
+  );
+}

--- a/client/src/components/ui/AppBottomSheet.tsx
+++ b/client/src/components/ui/AppBottomSheet.tsx
@@ -75,6 +75,7 @@ export const AppBottomSheet = ({
     ? requestedDetents
     : [programmatic(0), ...requestedDetents.slice(1)];
   const openIndex = resolvedDetents.length - 1;
+  const [sheetIndex, setSheetIndex] = useState(isOpen ? openIndex : 0);
   const openDetent = resolvedDetents[openIndex];
   const openDetentValue =
     typeof openDetent === "object" && openDetent !== null ? openDetent.value : openDetent;
@@ -85,6 +86,10 @@ export const AppBottomSheet = ({
         ? openDetentValue
         : undefined;
   const showsLiquidGlass = liquidGlass && Platform.OS === "ios" && Number(Platform.Version) >= 26;
+
+  useEffect(() => {
+    setSheetIndex(isOpen ? openIndex : 0);
+  }, [isOpen, openIndex]);
 
   useEffect(() => {
     if (!avoidKeyboard) {
@@ -112,10 +117,15 @@ export const AppBottomSheet = ({
 
   return (
     <ModalBottomSheet
-      index={isOpen ? openIndex : 0}
+      index={sheetIndex}
       detents={resolvedDetents}
       onIndexChange={(index) => {
+        setSheetIndex(index);
         if (index === 0) {
+          if (!dismissible && isOpen) {
+            requestAnimationFrame(() => setSheetIndex(openIndex));
+            return;
+          }
           onClose();
         }
       }}

--- a/client/src/components/ui/AppBottomSheet.tsx
+++ b/client/src/components/ui/AppBottomSheet.tsx
@@ -11,7 +11,7 @@ import {
   type KeyboardEvent,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { ModalBottomSheet, type Detent } from "@swmansion/react-native-bottom-sheet";
+import { ModalBottomSheet, programmatic, type Detent } from "@swmansion/react-native-bottom-sheet";
 
 import { useTheme } from "~/hooks/useTheme";
 
@@ -25,6 +25,7 @@ type AppBottomSheetProps = {
   scrollable?: boolean;
   avoidKeyboard?: boolean;
   liquidGlass?: boolean;
+  dismissible?: boolean;
 };
 
 function LiquidGlassSheetSurface() {
@@ -63,12 +64,16 @@ export const AppBottomSheet = ({
   scrollable = false,
   avoidKeyboard = false,
   liquidGlass = false,
+  dismissible = true,
 }: AppBottomSheetProps) => {
   const { height: windowHeight } = useWindowDimensions();
   const insets = useSafeAreaInsets();
   const [keyboardOffset, setKeyboardOffset] = useState(0);
   const sheetHeight = Math.max(windowHeight - Math.max(insets.top, 16) - 12, 320);
-  const resolvedDetents: Detent[] = detents ?? [0, "content"];
+  const requestedDetents: Detent[] = detents ?? [0, "content"];
+  const resolvedDetents: Detent[] = dismissible
+    ? requestedDetents
+    : [programmatic(0), ...requestedDetents.slice(1)];
   const openIndex = resolvedDetents.length - 1;
   const openDetent = resolvedDetents[openIndex];
   const openDetentValue =

--- a/client/src/components/ui/NativeNoahSecondaryButton.tsx
+++ b/client/src/components/ui/NativeNoahSecondaryButton.tsx
@@ -5,10 +5,7 @@ import {
   Text as ComposeText,
   TextButton as ComposeTextButton,
 } from "@expo/ui/jetpack-compose";
-import {
-  fillMaxSize,
-  testID as composeTestID,
-} from "@expo/ui/jetpack-compose/modifiers";
+import { fillMaxSize, testID as composeTestID } from "@expo/ui/jetpack-compose/modifiers";
 import {
   Platform,
   Pressable,
@@ -42,6 +39,8 @@ type NativeNoahSecondaryButtonProps = {
 const SECONDARY_COLORS = {
   accent: COLORS.BITCOIN_ORANGE,
   destructive: "#dc2626",
+  neutralDark: "#64748b",
+  neutralLight: "#94a3b8",
   darkText: "#f8fafc",
   lightText: "#1a2332",
   disabledText: "#64748b",
@@ -75,7 +74,13 @@ export function NativeNoahSecondaryButton({
   const height = BUTTON_HEIGHT[size];
   const buttonWidth = width ?? BUTTON_MIN_WIDTH[size];
   const accentColor =
-    tone === "destructive" ? SECONDARY_COLORS.destructive : SECONDARY_COLORS.accent;
+    tone === "destructive"
+      ? SECONDARY_COLORS.destructive
+      : tone === "neutral"
+        ? isDark
+          ? SECONDARY_COLORS.neutralDark
+          : SECONDARY_COLORS.neutralLight
+        : SECONDARY_COLORS.accent;
   const textColor = isDark ? SECONDARY_COLORS.darkText : SECONDARY_COLORS.lightText;
   const hostStyle = {
     width: "100%",

--- a/client/src/hooks/usePayments.ts
+++ b/client/src/hooks/usePayments.ts
@@ -64,11 +64,13 @@ export type LightningAddressPaymentRoute =
       destination: string;
       minSendableMsat: number;
       maxSendableMsat: number;
+      commentAllowed: number;
     }
   | {
       method: "lightning";
       minSendableMsat: number;
       maxSendableMsat: number;
+      commentAllowed: number;
     };
 
 const parseLightningAddress = (destination: string) => {
@@ -100,6 +102,7 @@ const paymentRouteFromLnurlpResponse = async (
   const limits = {
     minSendableMsat: response.minSendable,
     maxSendableMsat: response.maxSendable,
+    commentAllowed: response.commentAllowed,
   };
 
   if (acceptArkAddress && response.ark) {
@@ -493,10 +496,7 @@ const sendLightningAddressPayment = async (
     throw new Error("Payment amount is outside the supported range for this lightning address");
   }
 
-  if (
-    route.method === "ark" &&
-    shouldUseArkDirectLightningAddressRoute(route.method, comment)
-  ) {
+  if (route.method === "ark" && shouldUseArkDirectLightningAddressRoute(route.method, comment)) {
     log.d("Paying lightning address via Ark direct payment");
     const historyBeforeResult = await history();
     const existingMovementIds = historyBeforeResult.isOk()

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -1077,6 +1077,7 @@ export const useSendScreen = () => {
     lightningAddressSuggestions,
     handleSelectLightningAddressSuggestion,
     stage,
+    canGoBack: stageHistory.length > 1,
     startRecipientEntry,
     handleStageBack,
     handleAmountContinue,

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -108,6 +108,7 @@ export const useSendScreen = () => {
   const [destinationRequestRevision, setDestinationRequestRevision] = useState(0);
   const [isMaxSend, setIsMaxSend] = useState(false);
   const [stageHistory, setStageHistory] = useState<SendStage[]>(["amount"]);
+  const [stageDirection, setStageDirection] = useState<"back" | "forward">("forward");
   const [amountError, setAmountError] = useState<string | null>(null);
   const [recipientError, setRecipientError] = useState<string | null>(null);
   const [entry, setEntry] = useState<SendEntry>("amount-first");
@@ -127,6 +128,7 @@ export const useSendScreen = () => {
 
   const showStage = (nextStage: SendStage) => {
     setShowConfirmation(false);
+    setStageDirection("forward");
     setStageHistory((history) =>
       history.at(-1) === nextStage ? history : [...history, nextStage],
     );
@@ -134,6 +136,7 @@ export const useSendScreen = () => {
 
   const handleStageBack = () => {
     setShowConfirmation(false);
+    setStageDirection("back");
     if (stage === "recipient" && !isAmountEditable) {
       setDestination("");
       setAmount("");
@@ -309,6 +312,7 @@ export const useSendScreen = () => {
     setShowSuccess(false);
     setAmountError(null);
     setRecipientError(null);
+    setStageDirection("forward");
     setStageHistory(["recipient"]);
     setDestination(normalizeLightningAddressDestination(requestedDestination));
     setDestinationRequestRevision((revision) => revision + 1);
@@ -625,6 +629,7 @@ export const useSendScreen = () => {
     setAmountError(null);
     setRecipientError(null);
     setShowConfirmation(false);
+    setStageDirection("forward");
     setStageHistory(["source"]);
   };
 
@@ -1056,6 +1061,7 @@ export const useSendScreen = () => {
     setSelectedOnchainSource(null);
     setRailConfirmed(false);
     setSourceConfirmed(false);
+    setStageDirection("forward");
     setStageHistory(["amount"]);
     setAmountError(null);
     setRecipientError(null);
@@ -1083,6 +1089,7 @@ export const useSendScreen = () => {
     lightningAddressSuggestions,
     handleSelectLightningAddressSuggestion,
     stage,
+    stageDirection,
     canGoBack: stageHistory.length > 1,
     startRecipientEntry,
     handleStageBack,

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -34,7 +34,6 @@ import {
 } from "~/lib/repeatPayment";
 import { getMaxSendBalanceSat } from "~/lib/onchainSend";
 import {
-  canAddRecipientNote,
   getBip321MethodForRail,
   getBip321Rails,
   getNextSendStage,
@@ -105,7 +104,6 @@ export const useSendScreen = () => {
   );
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
-  const [isDestinationFocused, setIsDestinationFocused] = useState(false);
   const [destinationRequestRevision, setDestinationRequestRevision] = useState(0);
   const [isMaxSend, setIsMaxSend] = useState(false);
   const [stageHistory, setStageHistory] = useState<SendStage[]>(["amount"]);
@@ -135,6 +133,23 @@ export const useSendScreen = () => {
 
   const handleStageBack = () => {
     setShowConfirmation(false);
+    if (stage === "recipient" && !isAmountEditable) {
+      setDestination("");
+      setAmount("");
+      setParsedAmount(null);
+      setBip321Data(null);
+      setDestinationType(null);
+      setIsAmountEditable(true);
+      setComment("");
+      setEntry("amount-first");
+      setSelectedRail("onchain");
+      setSelectedPaymentMethod("onchain");
+      setSelectedOnchainSource(null);
+      setRailConfirmed(false);
+      setSourceConfirmed(false);
+      setStageHistory(["amount"]);
+      return;
+    }
     if (stage === "method") {
       setRailConfirmed(false);
     }
@@ -148,7 +163,7 @@ export const useSendScreen = () => {
 
   const startRecipientEntry = () => {
     setRecipientError(null);
-    if (!amount.trim()) {
+    if (!isMaxSend && !amount.trim()) {
       setEntry("recipient-first");
     }
     showStage("recipient");
@@ -207,17 +222,21 @@ export const useSendScreen = () => {
           setSelectedPaymentMethod("onchain");
         }
       }
-      setRailConfirmed(false);
-      setSourceConfirmed(false);
+      if (!isMaxSend) {
+        setRailConfirmed(false);
+        setSourceConfirmed(false);
+      }
     } else {
       setDestinationType(null);
       setIsAmountEditable(true);
       setParsedAmount(null);
       setBip321Data(null);
-      setRailConfirmed(false);
-      setSourceConfirmed(false);
+      if (!isMaxSend) {
+        setRailConfirmed(false);
+        setSourceConfirmed(false);
+      }
     }
-  }, [destination, destinationRequestRevision]);
+  }, [destination, destinationRequestRevision, isMaxSend]);
 
   const finalDestinationType =
     destinationType === "bip321" ? selectedPaymentMethod : destinationType;
@@ -281,7 +300,6 @@ export const useSendScreen = () => {
     setSourceConfirmed(false);
     setShowConfirmation(false);
     setShowSuccess(false);
-    setIsDestinationFocused(false);
     setAmountError(null);
     setRecipientError(null);
     setStageHistory(["recipient"]);
@@ -601,15 +619,6 @@ export const useSendScreen = () => {
     setStageHistory(["source"]);
   };
 
-  const handleSelectPaymentMethod = (method: "ark" | "lightning" | "onchain" | "offer") => {
-    setSelectedPaymentMethod(method);
-    setSelectedRail(method === "offer" ? "lightning" : method);
-    setRailConfirmed(false);
-    if (method !== "onchain") {
-      setIsMaxSend(false);
-    }
-  };
-
   const handleSelectRail = (rail: SendRail) => {
     setSelectedRail(rail);
     setRailConfirmed(false);
@@ -781,7 +790,6 @@ export const useSendScreen = () => {
     }
 
     // Show confirmation instead of sending immediately
-    setIsDestinationFocused(false);
     setShowConfirmation(true);
   };
 
@@ -915,7 +923,6 @@ export const useSendScreen = () => {
       }
     }
 
-    setIsDestinationFocused(false);
     reset();
     setParsedResult(null);
     setShowSuccess(false);
@@ -1033,27 +1040,6 @@ export const useSendScreen = () => {
     setComment("");
     setShowConfirmation(false);
     setShowSuccess(false);
-    setIsDestinationFocused(false);
-    setEntry("amount-first");
-    setSelectedRail("onchain");
-    setSelectedPaymentMethod("onchain");
-    setSelectedOnchainSource(null);
-    setRailConfirmed(false);
-    setSourceConfirmed(false);
-    setStageHistory(["amount"]);
-    setAmountError(null);
-    setRecipientError(null);
-  };
-
-  const handleClear = () => {
-    reset();
-    setDestination("");
-    setComment("");
-    setAmount("");
-    setIsMaxSend(false);
-    setShowConfirmation(false);
-    setShowSuccess(false);
-    setIsDestinationFocused(false);
     setEntry("amount-first");
     setSelectedRail("onchain");
     setSelectedPaymentMethod("onchain");
@@ -1067,7 +1053,6 @@ export const useSendScreen = () => {
 
   const handleSelectLightningAddressSuggestion = (suggestion: string) => {
     setEnteredDestination(suggestion);
-    setIsDestinationFocused(false);
   };
 
   const { showCamera, setShowCamera, handleScanPress, codeScanner } = useQRCodeScanner({
@@ -1085,8 +1070,6 @@ export const useSendScreen = () => {
   return {
     destination,
     setDestination: setEnteredDestination,
-    isDestinationFocused,
-    setIsDestinationFocused,
     lightningAddressSuggestions,
     handleSelectLightningAddressSuggestion,
     stage,
@@ -1107,23 +1090,15 @@ export const useSendScreen = () => {
     isAmountEditable,
     comment,
     setComment: setEnteredComment,
-    canAddNote: canAddRecipientNote(
-      finalDestinationType,
-      lightningAddressPaymentRouteQuery.data?.commentAllowed ?? 0,
-    ),
     commentAllowed: lightningAddressPaymentRouteQuery.data?.commentAllowed ?? 0,
     noteUsesLightning:
       lightningAddressPaymentRouteQuery.data?.method === "ark" && comment.trim().length > 0,
     isResolvingRecipient,
     parsedResult,
-    handleSend,
     handleConfirmSend,
     handleCancelConfirmation,
     handleDone,
-    handleClear,
     isSending,
-    error,
-    errorMessage,
     confirmationError: showConfirmation && error ? errorMessage : null,
     showCamera,
     setShowCamera,
@@ -1134,18 +1109,16 @@ export const useSendScreen = () => {
     toggleCurrency,
     amountSat,
     btcPrice,
-    parsedAmount,
     bip321Data,
     paymentRailOptions,
     railAvailability,
     selectedRail,
     setSelectedRail: handleSelectRail,
     selectedPaymentMethod,
-    setSelectedPaymentMethod: handleSelectPaymentMethod,
     onchainSourceOptions,
     selectedOnchainSource: resolvedOnchainSource,
     setSelectedOnchainSource: handleSelectOnchainSource,
-    resolvedOnchainSource,
+    confirmationAmountSat,
     isOnchainSourceSelectionRequired,
     isConfirmationAmountInvalid: !isMaxSend && amountSat <= 0,
     isCheckingOwnOnchainAddress: ownOnchainAddressQuery.isFetching,

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -518,6 +518,8 @@ export const useSendScreen = () => {
   ]);
 
   const feeEstimateQuery = useSendFeeEstimate(feeEstimateParams);
+  const isWaitingForFeeEstimate =
+    feeEstimateParams !== null && !feeEstimateQuery.data && !feeEstimateQuery.error;
 
   const feeEstimateNote = useMemo(() => {
     if (isMaxSend && resolvedOnchainSource === "onchain") {
@@ -1135,7 +1137,10 @@ export const useSendScreen = () => {
     destinationType,
     showSuccess,
     feeEstimate: feeEstimateQuery.data,
-    isEstimatingFee: lightningAddressPaymentRouteQuery.isFetching || feeEstimateQuery.isFetching,
+    isEstimatingFee:
+      lightningAddressPaymentRouteQuery.isFetching ||
+      feeEstimateQuery.isFetching ||
+      isWaitingForFeeEstimate,
     feeEstimateError: lightningAddressPaymentRouteQuery.error ?? feeEstimateQuery.error,
     feeEstimateUnavailableText: lightningAddressPaymentRouteQuery.error
       ? "Unable to determine whether this payment will use Ark or Lightning."

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -33,8 +33,17 @@ import {
   shouldUseArkDirectLightningAddressRoute,
 } from "~/lib/repeatPayment";
 import { getMaxSendBalanceSat } from "~/lib/onchainSend";
-import type { SendStage } from "~/lib/sendFlow";
-import { canAddRecipientNote } from "~/lib/sendFlow";
+import {
+  canAddRecipientNote,
+  getBip321MethodForRail,
+  getBip321Rails,
+  getNextSendStage,
+  getRecommendedRail,
+  isMaxCompatibleDestination,
+  type SendEntry,
+  type SendRail,
+  type SendStage,
+} from "~/lib/sendFlow";
 import { useProfileStore } from "~/store/profileStore";
 import logger from "~/lib/log";
 import type { TabParamList } from "~/Navigators";
@@ -102,6 +111,10 @@ export const useSendScreen = () => {
   const [stageHistory, setStageHistory] = useState<SendStage[]>(["amount"]);
   const [amountError, setAmountError] = useState<string | null>(null);
   const [recipientError, setRecipientError] = useState<string | null>(null);
+  const [entry, setEntry] = useState<SendEntry>("amount-first");
+  const [selectedRail, setSelectedRail] = useState<SendRail>("onchain");
+  const [railConfirmed, setRailConfirmed] = useState(false);
+  const [sourceConfirmed, setSourceConfirmed] = useState(false);
   const stage = stageHistory.at(-1) ?? "amount";
 
   const setEnteredDestination = (nextDestination: string) => {
@@ -122,6 +135,12 @@ export const useSendScreen = () => {
 
   const handleStageBack = () => {
     setShowConfirmation(false);
+    if (stage === "method") {
+      setRailConfirmed(false);
+    }
+    if (stage === "source") {
+      setSourceConfirmed(false);
+    }
     setStageHistory((history) =>
       history.length > 1 ? history.slice(0, -1) : history[0] === "amount" ? history : ["amount"],
     );
@@ -129,6 +148,9 @@ export const useSendScreen = () => {
 
   const startRecipientEntry = () => {
     setRecipientError(null);
+    if (!amount.trim()) {
+      setEntry("recipient-first");
+    }
     showStage("recipient");
   };
 
@@ -146,9 +168,10 @@ export const useSendScreen = () => {
 
       setDestinationType(newDestinationType);
       if (newAmount) {
-        setIsMaxSend(false);
-        setCurrency("SATS");
-        setAmount(newAmount.toString());
+        if (!isMaxSend) {
+          setCurrency("SATS");
+          setAmount(newAmount.toString());
+        }
         setParsedAmount(newAmount);
       } else if (parsedAmount) {
         setAmount("");
@@ -158,24 +181,41 @@ export const useSendScreen = () => {
 
       if (newDestinationType === "bip321" && bip321) {
         setBip321Data(bip321);
-        if (bip321.arkAddress) {
-          setSelectedPaymentMethod("ark");
-        } else if (bip321.lightningInvoice) {
-          setSelectedPaymentMethod("lightning");
-        } else if (bip321.offer) {
-          setSelectedPaymentMethod("offer");
-        } else {
-          setSelectedPaymentMethod("onchain");
+        const rails = getBip321Rails(bip321);
+        const recommendedRail = isMaxSend && bip321.onchainAddress ? "onchain" : rails[0];
+        if (recommendedRail) {
+          setSelectedRail(recommendedRail);
+          const method = getBip321MethodForRail(recommendedRail, bip321);
+          if (method) {
+            setSelectedPaymentMethod(method);
+          }
         }
       } else {
         setBip321Data(null);
+        if (newDestinationType === "ark") {
+          setSelectedRail("ark");
+          setSelectedPaymentMethod("ark");
+        } else if (
+          newDestinationType === "lightning" ||
+          newDestinationType === "offer" ||
+          newDestinationType === "lnurl"
+        ) {
+          setSelectedRail("lightning");
+          setSelectedPaymentMethod(newDestinationType === "offer" ? "offer" : "lightning");
+        } else if (newDestinationType === "onchain") {
+          setSelectedRail("onchain");
+          setSelectedPaymentMethod("onchain");
+        }
       }
+      setRailConfirmed(false);
+      setSourceConfirmed(false);
     } else {
       setDestinationType(null);
       setIsAmountEditable(true);
       setParsedAmount(null);
       setBip321Data(null);
-      setIsMaxSend(false);
+      setRailConfirmed(false);
+      setSourceConfirmed(false);
     }
   }, [destination, destinationRequestRevision]);
 
@@ -188,6 +228,21 @@ export const useSendScreen = () => {
   const lightningAddressPaymentRouteQuery = useLightningAddressPaymentRoute(
     lightningAddressPaymentRouteDestination,
   );
+  const isResolvingRecipient =
+    finalDestinationType === "lnurl" && lightningAddressPaymentRouteQuery.isFetching;
+  const selectedLightningAddressPaymentRoute = useMemo(() => {
+    const resolvedRoute = lightningAddressPaymentRouteQuery.data;
+    if (!resolvedRoute || selectedRail !== "lightning" || resolvedRoute.method !== "ark") {
+      return resolvedRoute;
+    }
+
+    return {
+      method: "lightning" as const,
+      minSendableMsat: resolvedRoute.minSendableMsat,
+      maxSendableMsat: resolvedRoute.maxSendableMsat,
+      commentAllowed: resolvedRoute.commentAllowed,
+    };
+  }, [lightningAddressPaymentRouteQuery.data, selectedRail]);
 
   const {
     mutate: send,
@@ -218,8 +273,12 @@ export const useSendScreen = () => {
     setParsedAmount(null);
     setBip321Data(null);
     setSelectedPaymentMethod("onchain");
+    setSelectedRail("onchain");
     setSelectedOnchainSource(null);
     setIsMaxSend(false);
+    setEntry("recipient-first");
+    setRailConfirmed(false);
+    setSourceConfirmed(false);
     setShowConfirmation(false);
     setShowSuccess(false);
     setIsDestinationFocused(false);
@@ -249,8 +308,60 @@ export const useSendScreen = () => {
   const onchainWalletBalance = balance?.onchain.confirmed ?? 0;
   const offchainWalletBalance = balance?.offchain.spendable ?? 0;
 
+  const paymentRailOptions = useMemo<SendRail[]>(() => {
+    if (destinationType === "bip321" && bip321Data) {
+      return getBip321Rails(bip321Data);
+    }
+    if (destinationType === "lnurl") {
+      return lightningAddressPaymentRouteQuery.data?.method === "ark" && !comment.trim()
+        ? ["ark", "lightning"]
+        : ["lightning"];
+    }
+    if (destinationType === "ark") {
+      return ["ark"];
+    }
+    if (destinationType === "lightning" || destinationType === "offer") {
+      return ["lightning"];
+    }
+    if (destinationType === "onchain") {
+      return ["onchain"];
+    }
+    return [];
+  }, [bip321Data, comment, destinationType, lightningAddressPaymentRouteQuery.data?.method]);
+
+  const railAvailability = useMemo<Record<SendRail, boolean>>(
+    () => ({
+      ark: amountSat > 0 && offchainWalletBalance >= amountSat,
+      lightning: amountSat > 0 && offchainWalletBalance >= amountSat,
+      onchain:
+        isMaxSend ||
+        (amountSat > 0 &&
+          (offchainWalletBalance >= amountSat || onchainWalletBalance >= amountSat)),
+    }),
+    [amountSat, isMaxSend, offchainWalletBalance, onchainWalletBalance],
+  );
+
+  useEffect(() => {
+    if (railConfirmed || isMaxSend || paymentRailOptions.length === 0) {
+      return;
+    }
+
+    const recommendedRail = getRecommendedRail(paymentRailOptions, railAvailability);
+    if (!recommendedRail) {
+      return;
+    }
+
+    setSelectedRail(recommendedRail);
+    if (destinationType === "bip321" && bip321Data) {
+      const method = getBip321MethodForRail(recommendedRail, bip321Data);
+      if (method) {
+        setSelectedPaymentMethod(method);
+      }
+    }
+  }, [bip321Data, destinationType, isMaxSend, paymentRailOptions, railAvailability, railConfirmed]);
+
   const onchainSourceOptions = useMemo<OnchainSendSource[]>(() => {
-    if (!isOnchainSend || !balance) {
+    if ((!isOnchainSend && !isMaxSend) || !balance) {
       return [];
     }
 
@@ -267,7 +378,7 @@ export const useSendScreen = () => {
   }, [amountSat, balance, isMaxSend, isOnchainSend, offchainWalletBalance, onchainWalletBalance]);
 
   useEffect(() => {
-    if (!isOnchainSend || (!isMaxSend && amountSat <= 0)) {
+    if ((!isOnchainSend && !isMaxSend) || (!isMaxSend && amountSat <= 0)) {
       setSelectedOnchainSource(null);
       return;
     }
@@ -282,12 +393,6 @@ export const useSendScreen = () => {
 
   const isOnchainSourceSelectionRequired =
     isOnchainSend && onchainSourceOptions.length > 1 && resolvedOnchainSource === null;
-
-  useEffect(() => {
-    if (!isOnchainSend || !isAmountEditable) {
-      setIsMaxSend(false);
-    }
-  }, [isAmountEditable, isOnchainSend]);
 
   const resolvedOnchainDestination = !isOnchainSend
     ? null
@@ -344,12 +449,14 @@ export const useSendScreen = () => {
       case "offer":
         return { method: "lightning", amountSat };
       case "lnurl": {
-        const route = lightningAddressPaymentRouteQuery.data;
+        const route = selectedLightningAddressPaymentRoute;
         return route
           ? {
-              method: shouldUseArkDirectLightningAddressRoute(route.method, comment || null)
-                ? "ark"
-                : "lightning",
+              method:
+                selectedRail === "ark" &&
+                shouldUseArkDirectLightningAddressRoute(route.method, comment || null)
+                  ? "ark"
+                  : "lightning",
               amountSat,
             }
           : null;
@@ -386,6 +493,8 @@ export const useSendScreen = () => {
     offchainWalletBalance,
     resolvedOnchainSource,
     selectedPaymentMethod,
+    selectedLightningAddressPaymentRoute,
+    selectedRail,
     showConfirmation,
   ]);
 
@@ -457,8 +566,18 @@ export const useSendScreen = () => {
 
   const setEnteredAmount = (nextAmount: string) => {
     setIsMaxSend(false);
+    if (entry === "max") {
+      setEntry("amount-first");
+      setSelectedOnchainSource(null);
+      setSourceConfirmed(false);
+    }
     setAmountError(null);
     setAmount(nextAmount);
+  };
+
+  const setEnteredComment = (nextComment: string) => {
+    setComment(nextComment);
+    setRailConfirmed(false);
   };
 
   const handleMaxSend = () => {
@@ -466,14 +585,55 @@ export const useSendScreen = () => {
     setCurrency("SATS");
     setParsedAmount(null);
     setIsMaxSend(true);
+    setEntry("max");
+    setDestination("");
+    setDestinationType(null);
+    setBip321Data(null);
+    setComment("");
+    setSelectedRail("onchain");
+    setSelectedPaymentMethod("onchain");
+    setSelectedOnchainSource(null);
+    setRailConfirmed(true);
+    setSourceConfirmed(false);
     setAmountError(null);
+    setRecipientError(null);
+    setShowConfirmation(false);
+    setStageHistory(["source"]);
   };
 
   const handleSelectPaymentMethod = (method: "ark" | "lightning" | "onchain" | "offer") => {
     setSelectedPaymentMethod(method);
+    setSelectedRail(method === "offer" ? "lightning" : method);
+    setRailConfirmed(false);
     if (method !== "onchain") {
       setIsMaxSend(false);
     }
+  };
+
+  const handleSelectRail = (rail: SendRail) => {
+    setSelectedRail(rail);
+    setRailConfirmed(false);
+    setSourceConfirmed(false);
+
+    if (destinationType === "bip321" && bip321Data) {
+      const method = getBip321MethodForRail(rail, bip321Data);
+      if (method) {
+        setSelectedPaymentMethod(method);
+      }
+    } else if (rail === "lightning") {
+      setSelectedPaymentMethod(destinationType === "offer" ? "offer" : "lightning");
+    } else {
+      setSelectedPaymentMethod(rail);
+    }
+
+    if (rail !== "onchain") {
+      setSelectedOnchainSource(null);
+    }
+  };
+
+  const handleSelectOnchainSource = (source: OnchainSendSource) => {
+    setSelectedOnchainSource(source);
+    setSourceConfirmed(false);
   };
 
   useEffect(() => {
@@ -625,6 +785,37 @@ export const useSendScreen = () => {
     setShowConfirmation(true);
   };
 
+  const continueToStage = (nextStage: SendStage) => {
+    if (nextStage === "review") {
+      handleSend();
+      return;
+    }
+
+    showStage(nextStage);
+  };
+
+  const getNextStage = ({
+    amountConfirmed,
+    recipientConfirmed,
+    nextRailConfirmed = railConfirmed,
+    nextSourceConfirmed = sourceConfirmed,
+  }: {
+    amountConfirmed: boolean;
+    recipientConfirmed: boolean;
+    nextRailConfirmed?: boolean;
+    nextSourceConfirmed?: boolean;
+  }) =>
+    getNextSendStage({
+      entry,
+      amountConfirmed,
+      recipientConfirmed,
+      railConfirmed: nextRailConfirmed,
+      sourceConfirmed: nextSourceConfirmed,
+      rails: paymentRailOptions,
+      selectedRail,
+      sourceOptions: onchainSourceOptions,
+    });
+
   const handleAmountContinue = () => {
     if (isNaN(amountSat) || amountSat <= 0) {
       setAmountError("Enter an amount greater than zero.");
@@ -632,12 +823,12 @@ export const useSendScreen = () => {
     }
 
     setAmountError(null);
-    if (isValidDestination(destination)) {
-      handleSend();
-      return;
-    }
-
-    showStage("recipient");
+    continueToStage(
+      getNextStage({
+        amountConfirmed: true,
+        recipientConfirmed: isValidDestination(destination),
+      }),
+    );
   };
 
   const handleRecipientContinue = () => {
@@ -648,13 +839,58 @@ export const useSendScreen = () => {
       return;
     }
 
-    setRecipientError(null);
-    if (!isMaxSend && amountSat <= 0) {
-      showStage("amount");
+    if (isMaxSend && !isMaxCompatibleDestination(destinationType, bip321Data)) {
+      setRecipientError("MAX can only be sent to an on-chain Bitcoin address.");
+      return;
+    }
+    if (isMaxSend && parsedAmount !== null) {
+      setRecipientError("MAX cannot be used with a fixed-amount payment request.");
       return;
     }
 
-    handleSend();
+    setRecipientError(null);
+    if (isResolvingRecipient) {
+      return;
+    }
+
+    continueToStage(
+      getNextStage({
+        amountConfirmed: isMaxSend || amountSat > 0,
+        recipientConfirmed: true,
+      }),
+    );
+  };
+
+  const handleRailContinue = () => {
+    if (!railAvailability[selectedRail]) {
+      return;
+    }
+
+    setRailConfirmed(true);
+    continueToStage(
+      getNextStage({
+        amountConfirmed: true,
+        recipientConfirmed: true,
+        nextRailConfirmed: true,
+      }),
+    );
+  };
+
+  const handleSourceContinue = () => {
+    if (!resolvedOnchainSource) {
+      return;
+    }
+
+    setSelectedOnchainSource(resolvedOnchainSource);
+    setSourceConfirmed(true);
+    continueToStage(
+      getNextStage({
+        amountConfirmed: true,
+        recipientConfirmed: isValidDestination(destination),
+        nextRailConfirmed: true,
+        nextSourceConfirmed: true,
+      }),
+    );
   };
 
   const handleConfirmSend = () => {
@@ -760,7 +996,7 @@ export const useSendScreen = () => {
           finalDestinationType === "onchain" ? (resolvedOnchainSource ?? undefined) : undefined,
         lightningAddressPaymentRoute:
           finalDestinationType === "lnurl" && lightningAddressPaymentRouteDestination
-            ? lightningAddressPaymentRouteQuery.data
+            ? selectedLightningAddressPaymentRoute
             : undefined,
         btcPrice,
         repeatPayment:
@@ -801,6 +1037,12 @@ export const useSendScreen = () => {
     setShowConfirmation(false);
     setShowSuccess(false);
     setIsDestinationFocused(false);
+    setEntry("amount-first");
+    setSelectedRail("onchain");
+    setSelectedPaymentMethod("onchain");
+    setSelectedOnchainSource(null);
+    setRailConfirmed(false);
+    setSourceConfirmed(false);
     setStageHistory(["amount"]);
     setAmountError(null);
     setRecipientError(null);
@@ -816,6 +1058,12 @@ export const useSendScreen = () => {
     setShowConfirmation(false);
     setShowSuccess(false);
     setIsDestinationFocused(false);
+    setEntry("amount-first");
+    setSelectedRail("onchain");
+    setSelectedPaymentMethod("onchain");
+    setSelectedOnchainSource(null);
+    setRailConfirmed(false);
+    setSourceConfirmed(false);
     setStageHistory(["amount"]);
     setAmountError(null);
     setRecipientError(null);
@@ -850,17 +1098,19 @@ export const useSendScreen = () => {
     handleStageBack,
     handleAmountContinue,
     handleRecipientContinue,
+    handleRailContinue,
+    handleSourceContinue,
     amountError,
     recipientError,
     amount,
     setAmount: setEnteredAmount,
     isMaxSend,
-    canSendMax: isOnchainSend && isAmountEditable,
+    canSendMax: isAmountEditable && (offchainWalletBalance > 0 || onchainWalletBalance > 0),
     handleMaxSend,
     maxSendAmountSat: maxSendBalanceSat,
     isAmountEditable,
     comment,
-    setComment,
+    setComment: setEnteredComment,
     canAddNote: canAddRecipientNote(
       finalDestinationType,
       lightningAddressPaymentRouteQuery.data?.commentAllowed ?? 0,
@@ -868,8 +1118,7 @@ export const useSendScreen = () => {
     commentAllowed: lightningAddressPaymentRouteQuery.data?.commentAllowed ?? 0,
     noteUsesLightning:
       lightningAddressPaymentRouteQuery.data?.method === "ark" && comment.trim().length > 0,
-    isResolvingRecipient:
-      finalDestinationType === "lnurl" && lightningAddressPaymentRouteQuery.isFetching,
+    isResolvingRecipient,
     parsedResult,
     handleSend,
     handleConfirmSend,
@@ -891,11 +1140,15 @@ export const useSendScreen = () => {
     btcPrice,
     parsedAmount,
     bip321Data,
+    paymentRailOptions,
+    railAvailability,
+    selectedRail,
+    setSelectedRail: handleSelectRail,
     selectedPaymentMethod,
     setSelectedPaymentMethod: handleSelectPaymentMethod,
     onchainSourceOptions,
     selectedOnchainSource: resolvedOnchainSource,
-    setSelectedOnchainSource,
+    setSelectedOnchainSource: handleSelectOnchainSource,
     resolvedOnchainSource,
     isOnchainSourceSelectionRequired,
     isConfirmationAmountInvalid: !isMaxSend && amountSat <= 0,

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -813,6 +813,7 @@ export const useSendScreen = () => {
       sourceConfirmed: nextSourceConfirmed,
       rails: paymentRailOptions,
       selectedRail,
+      selectedRailAvailable: railAvailability[selectedRail],
       sourceOptions: onchainSourceOptions,
     });
 

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -155,6 +155,22 @@ export const useSendScreen = () => {
       setStageHistory(["amount"]);
       return;
     }
+    if (
+      stage === "recipient" &&
+      entry === "amount-first" &&
+      stageHistory.at(-2) === "amount"
+    ) {
+      setDestination("");
+      setBip321Data(null);
+      setDestinationType(null);
+      setComment("");
+      setSelectedRail("onchain");
+      setSelectedPaymentMethod("onchain");
+      setSelectedOnchainSource(null);
+      setRailConfirmed(false);
+      setSourceConfirmed(false);
+      setRecipientError(null);
+    }
     if (stage === "method") {
       setRailConfirmed(false);
     }

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -683,7 +683,7 @@ export const useSendScreen = () => {
           amount_sat: res.amount_sat,
           destination: res.destination_address,
           txid: res.txid,
-          type: res.source === "offchain" ? "Onchain from Ark" : "Onchain",
+          type: res.source === "offchain" ? "On-chain from Ark balance" : "On-chain wallet",
         };
       }
 
@@ -693,7 +693,7 @@ export const useSendScreen = () => {
           success: true,
           amount_sat: res.amount_sat,
           destination: res.destination_pubkey,
-          type: "Arkoor",
+          type: "Ark",
         };
       }
 
@@ -1023,10 +1023,6 @@ export const useSendScreen = () => {
     setShowConfirmation(false);
   };
 
-  const handleCloseSuccess = () => {
-    setShowSuccess(false);
-  };
-
   const handleDone = () => {
     reset();
     setParsedResult(null);
@@ -1046,7 +1042,6 @@ export const useSendScreen = () => {
     setStageHistory(["amount"]);
     setAmountError(null);
     setRecipientError(null);
-    handleCloseSuccess();
   };
 
   const handleClear = () => {
@@ -1163,7 +1158,6 @@ export const useSendScreen = () => {
     showConfirmation,
     destinationType,
     showSuccess,
-    handleCloseSuccess,
     feeEstimate: feeEstimateQuery.data,
     isEstimatingFee: lightningAddressPaymentRouteQuery.isFetching || feeEstimateQuery.isFetching,
     feeEstimateError: lightningAddressPaymentRouteQuery.error ?? feeEstimateQuery.error,

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -37,6 +37,7 @@ import { getMaxSendBalanceSat } from "~/lib/onchainSend";
 import {
   getBip321MethodForRail,
   getBip321Rails,
+  getDestinationRails,
   getNextSendStage,
   getRecommendedRail,
   isMaxCompatibleDestination,
@@ -49,6 +50,8 @@ import logger from "~/lib/log";
 import type { TabParamList } from "~/Navigators";
 
 const log = logger("useSendScreen");
+const INVALID_DESTINATION_MESSAGE =
+  "Enter a valid Bitcoin address, Lightning invoice, Lightning offer, Lightning address, or Ark address.";
 
 type DisplayResult = {
   amount_sat: number;
@@ -115,7 +118,35 @@ export const useSendScreen = () => {
   const [selectedRail, setSelectedRail] = useState<SendRail>("onchain");
   const [railConfirmed, setRailConfirmed] = useState(false);
   const [sourceConfirmed, setSourceConfirmed] = useState(false);
+  const [recipientConfirmed, setRecipientConfirmed] = useState(false);
+  const [isEditingRecipient, setIsEditingRecipient] = useState(false);
   const stage = stageHistory.at(-1) ?? "amount";
+
+  const resetSendDraftState = () => {
+    setDestination("");
+    setAmount("");
+    setIsAmountEditable(true);
+    setComment("");
+    setParsedResult(null);
+    setDestinationType(null);
+    setParsedAmount(null);
+    setBip321Data(null);
+    setSelectedPaymentMethod("onchain");
+    setSelectedOnchainSource(null);
+    setShowConfirmation(false);
+    setShowSuccess(false);
+    setIsMaxSend(false);
+    setStageHistory(["amount"]);
+    setStageDirection("forward");
+    setAmountError(null);
+    setRecipientError(null);
+    setEntry("amount-first");
+    setSelectedRail("onchain");
+    setRailConfirmed(false);
+    setSourceConfirmed(false);
+    setRecipientConfirmed(false);
+    setIsEditingRecipient(false);
+  };
 
   const setEnteredDestination = (nextDestination: string) => {
     if (parsedAmount !== null) {
@@ -123,6 +154,7 @@ export const useSendScreen = () => {
       setParsedAmount(null);
     }
     setRecipientError(null);
+    setRecipientConfirmed(false);
     setDestination(nextDestination);
   };
 
@@ -137,28 +169,16 @@ export const useSendScreen = () => {
   const handleStageBack = () => {
     setShowConfirmation(false);
     setStageDirection("back");
-    if (stage === "recipient" && !isAmountEditable) {
-      setDestination("");
-      setAmount("");
-      setParsedAmount(null);
-      setBip321Data(null);
-      setDestinationType(null);
-      setIsMaxSend(false);
-      setIsAmountEditable(true);
-      setComment("");
-      setEntry("amount-first");
-      setSelectedRail("onchain");
-      setSelectedPaymentMethod("onchain");
-      setSelectedOnchainSource(null);
-      setRailConfirmed(false);
-      setSourceConfirmed(false);
-      setStageHistory(["amount"]);
+    if (stage === "recipient" && !isAmountEditable && !isEditingRecipient) {
+      resetSendDraftState();
+      setStageDirection("back");
       return;
     }
     if (
       stage === "recipient" &&
       entry === "amount-first" &&
-      stageHistory.at(-2) === "amount"
+      stageHistory.at(-2) === "amount" &&
+      !isEditingRecipient
     ) {
       setDestination("");
       setBip321Data(null);
@@ -170,6 +190,7 @@ export const useSendScreen = () => {
       setRailConfirmed(false);
       setSourceConfirmed(false);
       setRecipientError(null);
+      setRecipientConfirmed(false);
     }
     if (stage === "method") {
       setRailConfirmed(false);
@@ -180,19 +201,15 @@ export const useSendScreen = () => {
         setIsMaxSend(false);
         setEntry("amount-first");
         setSelectedOnchainSource(null);
+        setRailConfirmed(false);
       }
+    }
+    if (stage === "recipient") {
+      setIsEditingRecipient(false);
     }
     setStageHistory((history) =>
       history.length > 1 ? history.slice(0, -1) : history[0] === "amount" ? history : ["amount"],
     );
-  };
-
-  const startRecipientEntry = () => {
-    setRecipientError(null);
-    if (!isMaxSend && !amount.trim()) {
-      setEntry("recipient-first");
-    }
-    showStage("recipient");
   };
 
   useEffect(() => {
@@ -205,7 +222,9 @@ export const useSendScreen = () => {
         bip321,
       } = parseDestination(destination);
 
-      setRecipientError(parseError ?? null);
+      setRecipientError(
+        (currentError) => parseError ?? (newDestinationType === null ? currentError : null),
+      );
 
       setDestinationType(newDestinationType);
       if (newAmount) {
@@ -321,6 +340,8 @@ export const useSendScreen = () => {
     setSelectedRail("onchain");
     setSelectedOnchainSource(null);
     setIsMaxSend(false);
+    setRecipientConfirmed(false);
+    setIsEditingRecipient(false);
     setEntry("recipient-first");
     setRailConfirmed(false);
     setSourceConfirmed(false);
@@ -628,20 +649,28 @@ export const useSendScreen = () => {
   };
 
   const handleMaxSend = () => {
+    const preserveRecipient =
+      recipientConfirmed &&
+      parsedAmount === null &&
+      isMaxCompatibleDestination(destinationType, bip321Data);
+
     setAmount("");
     setCurrency("SATS");
     setParsedAmount(null);
     setIsMaxSend(true);
     setEntry("max");
-    setDestination("");
-    setDestinationType(null);
-    setBip321Data(null);
+    if (!preserveRecipient) {
+      setDestination("");
+      setDestinationType(null);
+      setBip321Data(null);
+    }
     setComment("");
     setSelectedRail("onchain");
     setSelectedPaymentMethod("onchain");
     setSelectedOnchainSource(null);
     setRailConfirmed(true);
     setSourceConfirmed(false);
+    setRecipientConfirmed(preserveRecipient);
     setAmountError(null);
     setRecipientError(null);
     setShowConfirmation(false);
@@ -789,9 +818,7 @@ export const useSendScreen = () => {
   const handleSend = () => {
     // Validation
     if (!isValidDestination(destination)) {
-      setRecipientError(
-        "Enter a valid Bitcoin address, Lightning invoice, Lightning offer, Lightning address, or Ark address.",
-      );
+      setRecipientError(INVALID_DESTINATION_MESSAGE);
       showStage("recipient");
       return;
     }
@@ -834,19 +861,19 @@ export const useSendScreen = () => {
 
   const getNextStage = ({
     amountConfirmed,
-    recipientConfirmed,
+    nextRecipientConfirmed = recipientConfirmed,
     nextRailConfirmed = railConfirmed,
     nextSourceConfirmed = sourceConfirmed,
   }: {
     amountConfirmed: boolean;
-    recipientConfirmed: boolean;
+    nextRecipientConfirmed?: boolean;
     nextRailConfirmed?: boolean;
     nextSourceConfirmed?: boolean;
   }) =>
     getNextSendStage({
       entry,
       amountConfirmed,
-      recipientConfirmed,
+      recipientConfirmed: nextRecipientConfirmed,
       railConfirmed: nextRailConfirmed,
       sourceConfirmed: nextSourceConfirmed,
       rails: paymentRailOptions,
@@ -854,6 +881,119 @@ export const useSendScreen = () => {
       selectedRailAvailable: railAvailability[selectedRail],
       sourceOptions: onchainSourceOptions,
     });
+
+  const handleImportedDestination = (value: string) => {
+    const normalizedDestination = normalizeLightningAddressDestination(value);
+    if (!normalizedDestination.trim()) {
+      return;
+    }
+
+    const parsed = parseDestination(normalizedDestination);
+    const isValidImport = parsed.destinationType !== null && !parsed.error;
+    const nextAmountSat = parsed.amount ?? (parsedAmount !== null ? 0 : amountSat);
+    const importedRails = getDestinationRails(parsed.destinationType, parsed.bip321 ?? null);
+    const importedRailAvailability: Record<SendRail, boolean> = {
+      ark: nextAmountSat > 0 && offchainWalletBalance >= nextAmountSat,
+      lightning: nextAmountSat > 0 && offchainWalletBalance >= nextAmountSat,
+      onchain:
+        nextAmountSat > 0 &&
+        (offchainWalletBalance >= nextAmountSat || onchainWalletBalance >= nextAmountSat),
+    };
+    const importedRail = getRecommendedRail(importedRails, importedRailAvailability);
+    const importedSourceOptions: OnchainSendSource[] = [];
+
+    if (importedRail === "onchain" && nextAmountSat > 0) {
+      if (offchainWalletBalance >= nextAmountSat) {
+        importedSourceOptions.push("offchain");
+      }
+      if (onchainWalletBalance >= nextAmountSat) {
+        importedSourceOptions.push("onchain");
+      }
+    }
+
+    setDestination(normalizedDestination);
+    setRecipientError(
+      parsed.error ?? (parsed.destinationType === null ? INVALID_DESTINATION_MESSAGE : null),
+    );
+    setDestinationType(parsed.destinationType);
+    setIsAmountEditable(parsed.isAmountEditable);
+    setBip321Data(parsed.bip321 ?? null);
+    setRailConfirmed(false);
+    setSourceConfirmed(false);
+    setSelectedOnchainSource(null);
+
+    if (parsed.amount) {
+      setCurrency("SATS");
+      setAmount(parsed.amount.toString());
+      setParsedAmount(parsed.amount);
+    } else if (parsedAmount !== null) {
+      setAmount("");
+      setParsedAmount(null);
+    }
+
+    if (importedRail) {
+      setSelectedRail(importedRail);
+      if (parsed.destinationType === "bip321" && parsed.bip321) {
+        const importedMethod = getBip321MethodForRail(importedRail, parsed.bip321);
+        if (importedMethod) {
+          setSelectedPaymentMethod(importedMethod);
+        }
+      } else if (importedRail === "lightning") {
+        setSelectedPaymentMethod(parsed.destinationType === "offer" ? "offer" : "lightning");
+      } else {
+        setSelectedPaymentMethod(importedRail);
+      }
+    }
+
+    if (stage !== "amount") {
+      setRecipientConfirmed(false);
+      setIsEditingRecipient(false);
+      return;
+    }
+
+    if (!isValidImport) {
+      setRecipientConfirmed(false);
+      setEntry(amountSat > 0 ? "amount-first" : "recipient-first");
+      showStage("recipient");
+      return;
+    }
+
+    if (parsed.destinationType === "lnurl") {
+      setRecipientConfirmed(false);
+      if (nextAmountSat <= 0) {
+        setEntry("recipient-first");
+        setStageHistory(["amount"]);
+      } else {
+        showStage("recipient");
+      }
+      return;
+    }
+
+    setRecipientConfirmed(true);
+    if (nextAmountSat <= 0) {
+      setEntry("recipient-first");
+      setStageHistory(["amount"]);
+      return;
+    }
+
+    const nextStage = getNextSendStage({
+      entry: amount.trim() ? "amount-first" : "recipient-first",
+      amountConfirmed: true,
+      recipientConfirmed: true,
+      railConfirmed: false,
+      sourceConfirmed: false,
+      rails: importedRails,
+      selectedRail: importedRail,
+      selectedRailAvailable: importedRail ? importedRailAvailability[importedRail] : false,
+      sourceOptions: importedSourceOptions,
+    });
+
+    if (nextStage === "review") {
+      setShowConfirmation(true);
+    } else {
+      showStage(nextStage);
+    }
+  };
 
   const handleAmountContinue = () => {
     if (isNaN(amountSat) || amountSat <= 0) {
@@ -865,16 +1005,13 @@ export const useSendScreen = () => {
     continueToStage(
       getNextStage({
         amountConfirmed: true,
-        recipientConfirmed: isValidDestination(destination),
       }),
     );
   };
 
   const handleRecipientContinue = () => {
     if (!isValidDestination(destination)) {
-      setRecipientError(
-        "Enter a valid Bitcoin address, Lightning invoice, Lightning offer, Lightning address, or Ark address.",
-      );
+      setRecipientError(INVALID_DESTINATION_MESSAGE);
       return;
     }
 
@@ -893,10 +1030,12 @@ export const useSendScreen = () => {
     }
 
     Keyboard.dismiss();
+    setRecipientConfirmed(true);
+    setIsEditingRecipient(false);
     continueToStage(
       getNextStage({
         amountConfirmed: isMaxSend || amountSat > 0,
-        recipientConfirmed: true,
+        nextRecipientConfirmed: true,
       }),
     );
   };
@@ -910,7 +1049,7 @@ export const useSendScreen = () => {
     continueToStage(
       getNextStage({
         amountConfirmed: true,
-        recipientConfirmed: true,
+        nextRecipientConfirmed: true,
         nextRailConfirmed: true,
       }),
     );
@@ -926,7 +1065,7 @@ export const useSendScreen = () => {
     continueToStage(
       getNextStage({
         amountConfirmed: true,
-        recipientConfirmed: isValidDestination(destination),
+        nextRecipientConfirmed: recipientConfirmed,
         nextRailConfirmed: true,
         nextSourceConfirmed: true,
       }),
@@ -1064,23 +1203,18 @@ export const useSendScreen = () => {
 
   const handleDone = () => {
     reset();
-    setParsedResult(null);
-    setDestination("");
-    setAmount("");
-    setIsMaxSend(false);
-    setComment("");
-    setShowConfirmation(false);
-    setShowSuccess(false);
-    setEntry("amount-first");
-    setSelectedRail("onchain");
-    setSelectedPaymentMethod("onchain");
-    setSelectedOnchainSource(null);
-    setRailConfirmed(false);
-    setSourceConfirmed(false);
-    setStageDirection("forward");
-    setStageHistory(["amount"]);
-    setAmountError(null);
+    resetSendDraftState();
+  };
+
+  const handleClear = () => {
+    reset();
+    resetSendDraftState();
+  };
+
+  const handleEditRecipient = () => {
     setRecipientError(null);
+    setIsEditingRecipient(true);
+    showStage("recipient");
   };
 
   const handleSelectLightningAddressSuggestion = (suggestion: string) => {
@@ -1088,10 +1222,7 @@ export const useSendScreen = () => {
   };
 
   const { showCamera, setShowCamera, handleScanPress, codeScanner } = useQRCodeScanner({
-    onScan: (value) => {
-      setEnteredDestination(normalizeLightningAddressDestination(value));
-      showStage("recipient");
-    },
+    onScan: handleImportedDestination,
   });
 
   const errorMessage = useMemo(() => {
@@ -1107,7 +1238,9 @@ export const useSendScreen = () => {
     stage,
     stageDirection,
     canGoBack: stageHistory.length > 1,
-    startRecipientEntry,
+    handleImportedDestination,
+    handleEditRecipient,
+    handleClear,
     handleStageBack,
     handleAmountContinue,
     handleRecipientContinue,
@@ -1118,7 +1251,16 @@ export const useSendScreen = () => {
     amount,
     setAmount: setEnteredAmount,
     isMaxSend,
-    canSendMax: isAmountEditable && (offchainWalletBalance > 0 || onchainWalletBalance > 0),
+    canSendMax:
+      isAmountEditable &&
+      (offchainWalletBalance > 0 || onchainWalletBalance > 0) &&
+      (!destination.trim() ||
+        (recipientConfirmed && isMaxCompatibleDestination(destinationType, bip321Data))),
+    canClear:
+      amount.trim().length > 0 ||
+      destination.trim().length > 0 ||
+      comment.trim().length > 0 ||
+      isMaxSend,
     handleMaxSend,
     maxSendAmountSat: maxSendBalanceSat,
     isAmountEditable,

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import { Keyboard } from "react-native";
 import { useRoute } from "@react-navigation/native";
 import type { RouteProp } from "@react-navigation/native";
 import { useAlert } from "~/contexts/AlertProvider";
@@ -862,6 +863,7 @@ export const useSendScreen = () => {
       return;
     }
 
+    Keyboard.dismiss();
     continueToStage(
       getNextStage({
         amountConfirmed: isMaxSend || amountSat > 0,

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -140,6 +140,7 @@ export const useSendScreen = () => {
       setParsedAmount(null);
       setBip321Data(null);
       setDestinationType(null);
+      setIsMaxSend(false);
       setIsAmountEditable(true);
       setComment("");
       setEntry("amount-first");
@@ -156,6 +157,11 @@ export const useSendScreen = () => {
     }
     if (stage === "source") {
       setSourceConfirmed(false);
+      if (entry === "max" && stageHistory.length === 1) {
+        setIsMaxSend(false);
+        setEntry("amount-first");
+        setSelectedOnchainSource(null);
+      }
     }
     setStageHistory((history) =>
       history.length > 1 ? history.slice(0, -1) : history[0] === "amount" ? history : ["amount"],

--- a/client/src/hooks/useSendScreen.ts
+++ b/client/src/hooks/useSendScreen.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useRoute } from "@react-navigation/native";
 import type { RouteProp } from "@react-navigation/native";
 import { useAlert } from "~/contexts/AlertProvider";
@@ -33,6 +33,8 @@ import {
   shouldUseArkDirectLightningAddressRoute,
 } from "~/lib/repeatPayment";
 import { getMaxSendBalanceSat } from "~/lib/onchainSend";
+import type { SendStage } from "~/lib/sendFlow";
+import { canAddRecipientNote } from "~/lib/sendFlow";
 import { useProfileStore } from "~/store/profileStore";
 import logger from "~/lib/log";
 import type { TabParamList } from "~/Navigators";
@@ -97,6 +99,38 @@ export const useSendScreen = () => {
   const [isDestinationFocused, setIsDestinationFocused] = useState(false);
   const [destinationRequestRevision, setDestinationRequestRevision] = useState(0);
   const [isMaxSend, setIsMaxSend] = useState(false);
+  const [stageHistory, setStageHistory] = useState<SendStage[]>(["amount"]);
+  const [amountError, setAmountError] = useState<string | null>(null);
+  const [recipientError, setRecipientError] = useState<string | null>(null);
+  const stage = stageHistory.at(-1) ?? "amount";
+
+  const setEnteredDestination = (nextDestination: string) => {
+    if (parsedAmount !== null) {
+      setAmount("");
+      setParsedAmount(null);
+    }
+    setRecipientError(null);
+    setDestination(nextDestination);
+  };
+
+  const showStage = (nextStage: SendStage) => {
+    setShowConfirmation(false);
+    setStageHistory((history) =>
+      history.at(-1) === nextStage ? history : [...history, nextStage],
+    );
+  };
+
+  const handleStageBack = () => {
+    setShowConfirmation(false);
+    setStageHistory((history) =>
+      history.length > 1 ? history.slice(0, -1) : history[0] === "amount" ? history : ["amount"],
+    );
+  };
+
+  const startRecipientEntry = () => {
+    setRecipientError(null);
+    showStage("recipient");
+  };
 
   useEffect(() => {
     if (destination) {
@@ -108,9 +142,7 @@ export const useSendScreen = () => {
         bip321,
       } = parseDestination(destination);
 
-      if (parseError) {
-        showAlert({ title: "Invalid Destination", description: parseError });
-      }
+      setRecipientError(parseError ?? null);
 
       setDestinationType(newDestinationType);
       if (newAmount) {
@@ -140,20 +172,19 @@ export const useSendScreen = () => {
       }
     } else {
       setDestinationType(null);
-      setAmount("");
       setIsAmountEditable(true);
       setParsedAmount(null);
       setBip321Data(null);
       setIsMaxSend(false);
     }
-  }, [destination, destinationRequestRevision, showAlert]);
+  }, [destination, destinationRequestRevision]);
 
   const finalDestinationType =
     destinationType === "bip321" ? selectedPaymentMethod : destinationType;
   const cleanedDestination = destination.trim().replace(/^(bitcoin:|lightning:)/i, "");
   const normalizedLnurlDestination = normalizeLightningAddress(cleanedDestination);
   const lightningAddressPaymentRouteDestination =
-    showConfirmation && finalDestinationType === "lnurl" ? normalizedLnurlDestination : null;
+    finalDestinationType === "lnurl" ? normalizedLnurlDestination : null;
   const lightningAddressPaymentRouteQuery = useLightningAddressPaymentRoute(
     lightningAddressPaymentRouteDestination,
   );
@@ -192,13 +223,16 @@ export const useSendScreen = () => {
     setShowConfirmation(false);
     setShowSuccess(false);
     setIsDestinationFocused(false);
+    setAmountError(null);
+    setRecipientError(null);
+    setStageHistory(["recipient"]);
     setDestination(normalizeLightningAddressDestination(requestedDestination));
     setDestinationRequestRevision((revision) => revision + 1);
   }, [fiatCurrency, reset, route.params]);
 
   const { suggestions: lightningAddressSuggestions } = useLightningAddressSuggestions({
     destination,
-    isDestinationFocused,
+    isDestinationFocused: stage === "recipient",
   });
 
   const amountSat = useMemo(() => {
@@ -423,6 +457,7 @@ export const useSendScreen = () => {
 
   const setEnteredAmount = (nextAmount: string) => {
     setIsMaxSend(false);
+    setAmountError(null);
     setAmount(nextAmount);
   };
 
@@ -431,6 +466,7 @@ export const useSendScreen = () => {
     setCurrency("SATS");
     setParsedAmount(null);
     setIsMaxSend(true);
+    setAmountError(null);
   };
 
   const handleSelectPaymentMethod = (method: "ark" | "lightning" | "onchain" | "offer") => {
@@ -458,7 +494,7 @@ export const useSendScreen = () => {
     ]);
   }, [lightningAddressPaymentRouteQuery.error]);
 
-  const toggleCurrency = useCallback(() => {
+  const toggleCurrency = () => {
     if (currency === "SATS") {
       if (btcPrice && amount) {
         setAmount(satsToFiat(parseInt(amount, 10), btcPrice, fiatCurrency));
@@ -470,7 +506,7 @@ export const useSendScreen = () => {
       }
       setCurrency("SATS");
     }
-  }, [currency, btcPrice, amount, fiatCurrency]);
+  };
 
   useEffect(() => {
     if (!result) {
@@ -554,15 +590,15 @@ export const useSendScreen = () => {
   const handleSend = () => {
     // Validation
     if (!isValidDestination(destination)) {
-      showAlert({
-        title: "Invalid Destination",
-        description:
-          "Please enter a valid Bitcoin address, BOLT11 invoice, BOLT12 offer, Lightning Address, or Ark public key.",
-      });
+      setRecipientError(
+        "Enter a valid Bitcoin address, Lightning invoice, Lightning offer, Lightning address, or Ark address.",
+      );
+      showStage("recipient");
       return;
     }
     if (!isMaxSend && (isNaN(amountSat) || amountSat <= 0)) {
-      showAlert({ title: "Invalid Amount", description: "Please enter a valid amount." });
+      setAmountError("Enter an amount greater than zero.");
+      showStage("amount");
       return;
     }
     if (isOnchainSend) {
@@ -587,6 +623,38 @@ export const useSendScreen = () => {
     // Show confirmation instead of sending immediately
     setIsDestinationFocused(false);
     setShowConfirmation(true);
+  };
+
+  const handleAmountContinue = () => {
+    if (isNaN(amountSat) || amountSat <= 0) {
+      setAmountError("Enter an amount greater than zero.");
+      return;
+    }
+
+    setAmountError(null);
+    if (isValidDestination(destination)) {
+      handleSend();
+      return;
+    }
+
+    showStage("recipient");
+  };
+
+  const handleRecipientContinue = () => {
+    if (!isValidDestination(destination)) {
+      setRecipientError(
+        "Enter a valid Bitcoin address, Lightning invoice, Lightning offer, Lightning address, or Ark address.",
+      );
+      return;
+    }
+
+    setRecipientError(null);
+    if (!isMaxSend && amountSat <= 0) {
+      showStage("amount");
+      return;
+    }
+
+    handleSend();
   };
 
   const handleConfirmSend = () => {
@@ -733,6 +801,9 @@ export const useSendScreen = () => {
     setShowConfirmation(false);
     setShowSuccess(false);
     setIsDestinationFocused(false);
+    setStageHistory(["amount"]);
+    setAmountError(null);
+    setRecipientError(null);
     handleCloseSuccess();
   };
 
@@ -745,16 +816,20 @@ export const useSendScreen = () => {
     setShowConfirmation(false);
     setShowSuccess(false);
     setIsDestinationFocused(false);
+    setStageHistory(["amount"]);
+    setAmountError(null);
+    setRecipientError(null);
   };
 
-  const handleSelectLightningAddressSuggestion = useCallback((suggestion: string) => {
-    setDestination(suggestion);
+  const handleSelectLightningAddressSuggestion = (suggestion: string) => {
+    setEnteredDestination(suggestion);
     setIsDestinationFocused(false);
-  }, []);
+  };
 
   const { showCamera, setShowCamera, handleScanPress, codeScanner } = useQRCodeScanner({
     onScan: (value) => {
-      setDestination(normalizeLightningAddressDestination(value));
+      setEnteredDestination(normalizeLightningAddressDestination(value));
+      showStage("recipient");
     },
   });
 
@@ -765,11 +840,18 @@ export const useSendScreen = () => {
 
   return {
     destination,
-    setDestination,
+    setDestination: setEnteredDestination,
     isDestinationFocused,
     setIsDestinationFocused,
     lightningAddressSuggestions,
     handleSelectLightningAddressSuggestion,
+    stage,
+    startRecipientEntry,
+    handleStageBack,
+    handleAmountContinue,
+    handleRecipientContinue,
+    amountError,
+    recipientError,
     amount,
     setAmount: setEnteredAmount,
     isMaxSend,
@@ -779,6 +861,15 @@ export const useSendScreen = () => {
     isAmountEditable,
     comment,
     setComment,
+    canAddNote: canAddRecipientNote(
+      finalDestinationType,
+      lightningAddressPaymentRouteQuery.data?.commentAllowed ?? 0,
+    ),
+    commentAllowed: lightningAddressPaymentRouteQuery.data?.commentAllowed ?? 0,
+    noteUsesLightning:
+      lightningAddressPaymentRouteQuery.data?.method === "ark" && comment.trim().length > 0,
+    isResolvingRecipient:
+      finalDestinationType === "lnurl" && lightningAddressPaymentRouteQuery.isFetching,
     parsedResult,
     handleSend,
     handleConfirmSend,

--- a/client/src/lib/fiatCurrency.ts
+++ b/client/src/lib/fiatCurrency.ts
@@ -53,6 +53,10 @@ export const satsToFiat = (sats: number, btcPrice: number, currency: FiatCurrenc
 };
 
 export const fiatToSats = (amount: number, btcPrice: number): number => {
+  if (!Number.isFinite(amount)) {
+    return 0;
+  }
+
   return Math.round((amount / btcPrice) * 100_000_000);
 };
 

--- a/client/src/lib/sendFlow.ts
+++ b/client/src/lib/sendFlow.ts
@@ -45,6 +45,11 @@ export const getBip321MethodForRail = (
   return request.onchainAddress ? "onchain" : null;
 };
 
+export const getRecommendedRail = (
+  rails: readonly SendRail[],
+  availability: Readonly<Partial<Record<SendRail, boolean>>>,
+): SendRail | null => rails.find((rail) => availability[rail] !== false) ?? rails[0] ?? null;
+
 export const canAddRecipientNote = (
   destinationType: DestinationTypes,
   commentAllowed: number,
@@ -85,7 +90,7 @@ export const getNextSendStage = (progress: SendFlowProgress): SendStage => {
 
   if (
     progress.selectedRail === "onchain" &&
-    progress.sourceOptions.length > 1 &&
+    progress.sourceOptions.length !== 1 &&
     !progress.sourceConfirmed
   ) {
     return "source";

--- a/client/src/lib/sendFlow.ts
+++ b/client/src/lib/sendFlow.ts
@@ -5,6 +5,22 @@ export type SendRail = "ark" | "lightning" | "onchain";
 export type SendStage = "amount" | "recipient" | "method" | "source" | "review";
 export type SendEntry = "amount-first" | "recipient-first" | "max";
 
+const SEND_RAIL_LABELS: Record<SendRail, string> = {
+  ark: "Ark",
+  lightning: "Lightning",
+  onchain: "On-chain",
+};
+
+const ONCHAIN_SOURCE_LABELS: Record<OnchainSendSource, string> = {
+  offchain: "Ark balance",
+  onchain: "On-chain wallet",
+};
+
+export const getSendRailLabel = (rail: SendRail): string => SEND_RAIL_LABELS[rail];
+
+export const getOnchainSourceLabel = (source: OnchainSendSource): string =>
+  ONCHAIN_SOURCE_LABELS[source];
+
 export type SendFlowProgress = {
   entry: SendEntry;
   amountConfirmed: boolean;

--- a/client/src/lib/sendFlow.ts
+++ b/client/src/lib/sendFlow.ts
@@ -21,6 +21,25 @@ export const getSendRailLabel = (rail: SendRail): string => SEND_RAIL_LABELS[rai
 export const getOnchainSourceLabel = (source: OnchainSendSource): string =>
   ONCHAIN_SOURCE_LABELS[source];
 
+export const getDestinationLabel = (destinationType: DestinationTypes): string | null => {
+  switch (destinationType) {
+    case "ark":
+      return "Ark address";
+    case "lightning":
+      return "Lightning invoice";
+    case "offer":
+      return "Lightning offer";
+    case "lnurl":
+      return "Lightning address";
+    case "onchain":
+      return "On-chain address";
+    case "bip321":
+      return "Bitcoin payment request";
+    default:
+      return null;
+  }
+};
+
 export type SendFlowProgress = {
   entry: SendEntry;
   amountConfirmed: boolean;
@@ -47,6 +66,29 @@ export const getBip321Rails = (request: ParsedBip321): SendRail[] => {
   }
 
   return rails;
+};
+
+export const getDestinationRails = (
+  destinationType: DestinationTypes,
+  request: ParsedBip321 | null,
+): SendRail[] => {
+  if (destinationType === "bip321" && request) {
+    return getBip321Rails(request);
+  }
+  if (destinationType === "ark") {
+    return ["ark"];
+  }
+  if (
+    destinationType === "lightning" ||
+    destinationType === "offer" ||
+    destinationType === "lnurl"
+  ) {
+    return ["lightning"];
+  }
+  if (destinationType === "onchain") {
+    return ["onchain"];
+  }
+  return [];
 };
 
 export const getBip321MethodForRail = (

--- a/client/src/lib/sendFlow.ts
+++ b/client/src/lib/sendFlow.ts
@@ -1,0 +1,95 @@
+import type { DestinationTypes, ParsedBip321 } from "~/lib/sendUtils";
+import type { OnchainSendSource } from "~/lib/paymentsApi";
+
+export type SendRail = "ark" | "lightning" | "onchain";
+export type SendStage = "amount" | "recipient" | "method" | "source" | "review";
+export type SendEntry = "amount-first" | "recipient-first" | "max";
+
+export type SendFlowProgress = {
+  entry: SendEntry;
+  amountConfirmed: boolean;
+  recipientConfirmed: boolean;
+  railConfirmed: boolean;
+  sourceConfirmed: boolean;
+  rails: readonly SendRail[];
+  selectedRail: SendRail | null;
+  sourceOptions: readonly OnchainSendSource[];
+};
+
+export const getBip321Rails = (request: ParsedBip321): SendRail[] => {
+  const rails: SendRail[] = [];
+
+  if (request.arkAddress) {
+    rails.push("ark");
+  }
+  if (request.lightningInvoice || request.offer) {
+    rails.push("lightning");
+  }
+  if (request.onchainAddress) {
+    rails.push("onchain");
+  }
+
+  return rails;
+};
+
+export const getBip321MethodForRail = (
+  rail: SendRail,
+  request: ParsedBip321,
+): "ark" | "lightning" | "offer" | "onchain" | null => {
+  if (rail === "ark") {
+    return request.arkAddress ? "ark" : null;
+  }
+  if (rail === "lightning") {
+    return request.lightningInvoice ? "lightning" : request.offer ? "offer" : null;
+  }
+  return request.onchainAddress ? "onchain" : null;
+};
+
+export const canAddRecipientNote = (
+  destinationType: DestinationTypes,
+  commentAllowed: number,
+): boolean => destinationType === "lnurl" && commentAllowed > 0;
+
+export const isMaxCompatibleDestination = (
+  destinationType: DestinationTypes,
+  request: ParsedBip321 | null,
+): boolean =>
+  destinationType === "onchain" ||
+  (destinationType === "bip321" && request?.onchainAddress !== undefined);
+
+export const getNextSendStage = (progress: SendFlowProgress): SendStage => {
+  if (progress.entry === "max") {
+    if (!progress.sourceConfirmed) {
+      return "source";
+    }
+    return progress.recipientConfirmed ? "review" : "recipient";
+  }
+
+  const primaryStages =
+    progress.entry === "amount-first"
+      ? (["amount", "recipient"] as const)
+      : (["recipient", "amount"] as const);
+
+  for (const stage of primaryStages) {
+    if (stage === "amount" && !progress.amountConfirmed) {
+      return "amount";
+    }
+    if (stage === "recipient" && !progress.recipientConfirmed) {
+      return "recipient";
+    }
+  }
+
+  if (progress.rails.length > 1 && !progress.railConfirmed) {
+    return "method";
+  }
+
+  if (
+    progress.selectedRail === "onchain" &&
+    progress.sourceOptions.length > 1 &&
+    !progress.sourceConfirmed
+  ) {
+    return "source";
+  }
+
+  return "review";
+};

--- a/client/src/lib/sendFlow.ts
+++ b/client/src/lib/sendFlow.ts
@@ -13,6 +13,7 @@ export type SendFlowProgress = {
   sourceConfirmed: boolean;
   rails: readonly SendRail[];
   selectedRail: SendRail | null;
+  selectedRailAvailable: boolean;
   sourceOptions: readonly OnchainSendSource[];
 };
 
@@ -84,7 +85,10 @@ export const getNextSendStage = (progress: SendFlowProgress): SendStage => {
     }
   }
 
-  if (progress.rails.length > 1 && !progress.railConfirmed) {
+  if (
+    (progress.rails.length > 1 || progress.selectedRailAvailable === false) &&
+    !progress.railConfirmed
+  ) {
     return "method";
   }
 

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -251,6 +251,7 @@ const SendScreen = () => {
             isOnchainSourceSelectionRequired ||
             isConfirmationAmountInvalid ||
             isLightningAddressPaymentRouteResolutionRequired ||
+            isEstimatingFee ||
             isCheckingOwnOnchainAddress ||
             isOwnOnchainAddress
           }

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -94,8 +94,7 @@ const SendScreen = () => {
     }
   }, [isFocused, setShowCamera, showCamera]);
 
-  const pasteDestination = async () => {
-    const value = await Clipboard.getStringAsync();
+  const applyPastedDestination = (value: string) => {
     if (!value.trim()) {
       return;
     }
@@ -104,8 +103,23 @@ const SendScreen = () => {
     startRecipientEntry();
   };
 
+  const pasteDestination = async () => {
+    applyPastedDestination(await Clipboard.getStringAsync());
+  };
+
+  const pasteDestinationFromScanner = (value: string) => {
+    setShowCamera(false);
+    applyPastedDestination(value);
+  };
+
   if (showCamera) {
-    return <QRCodeScanner codeScanner={codeScanner} onClose={() => setShowCamera(false)} />;
+    return (
+      <QRCodeScanner
+        codeScanner={codeScanner}
+        onClose={() => setShowCamera(false)}
+        onPaste={pasteDestinationFromScanner}
+      />
+    );
   }
 
   const railChoices: SendChoiceOption<SendRail>[] = paymentRailOptions.map((rail) => ({

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -1,61 +1,48 @@
-import React from "react";
-import { useSendScreen } from "../hooks/useSendScreen";
-import { SendSuccessBottomSheet } from "../components/SendSuccessBottomSheet";
+import { useIsFocused } from "@react-navigation/native";
+import * as Clipboard from "expo-clipboard";
+import { useEffect } from "react";
+
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
 import { QRCodeScanner } from "~/components/QRCodeScanner";
-import {
-  View,
-  TextInput,
-  TouchableOpacity,
-  TouchableWithoutFeedback,
-  Keyboard,
-  Pressable,
-  ScrollView,
-} from "react-native";
-
-import Icon from "@react-native-vector-icons/ionicons";
-import { useIconColor, useThemeColors } from "../hooks/useTheme";
-import * as Clipboard from "expo-clipboard";
-import { formatFiatAmount, getFiatCurrencyInfo, satsToFiat } from "~/lib/fiatCurrency";
-import { useIsFocused } from "@react-navigation/native";
-import { Button } from "~/components/ui/button";
-import { Text } from "~/components/ui/text";
-import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
 import { SendConfirmation } from "~/components/SendConfirmation";
-import { CurrencyToggle } from "~/components/CurrencyToggle";
-import { COLORS } from "~/lib/styleConstants";
-import { useBottomTabBarHeight } from "react-native-bottom-tabs";
-import { BlinkingCaret } from "~/components/BlinkingCaret";
-import { useBitcoinAmountFormatter, useBitcoinAmountUnit } from "~/hooks/useBitcoinAmountFormatter";
+import { SendSuccessBottomSheet } from "~/components/SendSuccessBottomSheet";
+import { SendAmountStage } from "~/components/send/SendAmountStage";
+import { SendRecipientStage } from "~/components/send/SendRecipientStage";
+import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
+import { useSendScreen } from "~/hooks/useSendScreen";
 
 const SendScreen = () => {
   const isFocused = useIsFocused();
-  const iconColor = useIconColor();
-  const colors = useThemeColors();
-  const formatBitcoinAmount = useBitcoinAmountFormatter();
-  const bitcoinAmountUnit = useBitcoinAmountUnit();
-  const bottomTabBarHeight = useBottomTabBarHeight();
-  const destinationInputRef = React.useRef<TextInput>(null);
-  const amountInputRef = React.useRef<TextInput>(null);
-  const [isAmountFocused, setIsAmountFocused] = React.useState(false);
   const {
+    stage,
+    amount,
+    amountSat,
+    setAmount,
+    amountError,
+    currency,
+    fiatCurrency,
+    btcPrice,
+    toggleCurrency,
+    offchainWalletBalance,
+    onchainWalletBalance,
     destination,
     setDestination,
-    isDestinationFocused,
-    setIsDestinationFocused,
+    destinationType,
+    bip321Data,
+    recipientError,
     lightningAddressSuggestions,
     handleSelectLightningAddressSuggestion,
-    amount,
-    setAmount,
-    isMaxSend,
-    canSendMax,
-    handleMaxSend,
-    maxSendAmountSat,
-    isAmountEditable,
     comment,
     setComment,
+    commentAllowed,
+    noteUsesLightning,
+    isResolvingRecipient,
+    startRecipientEntry,
+    handleStageBack,
+    handleAmountContinue,
+    handleRecipientContinue,
+    handleMaxSend,
     parsedResult,
-    handleSend,
     handleConfirmSend,
     handleCancelConfirmation,
     handleDone,
@@ -64,13 +51,6 @@ const SendScreen = () => {
     setShowCamera,
     handleScanPress,
     codeScanner,
-    currency,
-    fiatCurrency,
-    toggleCurrency,
-    amountSat,
-    btcPrice,
-    parsedAmount,
-    bip321Data,
     selectedPaymentMethod,
     setSelectedPaymentMethod,
     onchainSourceOptions,
@@ -81,11 +61,7 @@ const SendScreen = () => {
     isCheckingOwnOnchainAddress,
     isOwnOnchainAddress,
     isLightningAddressPaymentRouteResolutionRequired,
-    onchainWalletBalance,
-    offchainWalletBalance,
-    handleClear,
     showConfirmation,
-    destinationType,
     showSuccess,
     handleCloseSuccess,
     feeEstimate,
@@ -95,57 +71,25 @@ const SendScreen = () => {
     feeEstimateNote,
     feeEstimateWarning,
     confirmationError,
+    isMaxSend,
+    maxSendAmountSat,
   } = useSendScreen();
-  const fiatCurrencyInfo = getFiatCurrencyInfo(fiatCurrency);
-  const displayAmount = isMaxSend
-    ? maxSendAmountSat.toLocaleString()
-    : amount === ""
-      ? currency === "FIAT"
-        ? "0.00"
-        : "0"
-      : amount;
-  const amountPrefix =
-    currency === "FIAT" ? fiatCurrencyInfo.symbol : bitcoinAmountUnit === "bip177" ? "₿" : null;
-  const amountSuffix = currency === "SATS" && bitcoinAmountUnit === "sats" ? "sats" : null;
 
-  const handlePaste = async () => {
-    const text = await Clipboard.getStringAsync();
-    setDestination(text);
-  };
-
-  const focusDestinationInput = React.useCallback(() => {
-    setIsDestinationFocused(true);
-    requestAnimationFrame(() => {
-      destinationInputRef.current?.focus();
-    });
-  }, [setIsDestinationFocused]);
-
-  const focusAmountInput = React.useCallback(() => {
-    if (!isAmountEditable) {
-      return;
-    }
-
-    setAmount(amount);
-    requestAnimationFrame(() => {
-      amountInputRef.current?.focus();
-    });
-  }, [amount, isAmountEditable, setAmount]);
-
-  React.useEffect(() => {
-    if (isAmountEditable) {
-      return;
-    }
-
-    amountInputRef.current?.blur();
-    setIsAmountFocused(false);
-  }, [isAmountEditable]);
-
-  // Close scanner when navigating away from the screen
-  React.useEffect(() => {
+  useEffect(() => {
     if (!isFocused && showCamera) {
       setShowCamera(false);
     }
-  }, [isFocused, showCamera, setShowCamera]);
+  }, [isFocused, setShowCamera, showCamera]);
+
+  const pasteDestination = async () => {
+    const value = await Clipboard.getStringAsync();
+    if (!value.trim()) {
+      return;
+    }
+
+    setDestination(value);
+    startRecipientEntry();
+  };
 
   if (showCamera) {
     return <QRCodeScanner codeScanner={codeScanner} onClose={() => setShowCamera(false)} />;
@@ -153,279 +97,47 @@ const SendScreen = () => {
 
   return (
     <NoahSafeAreaView className="flex-1 bg-background">
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <View className="flex-1">
-          <View className="flex-row items-center px-5 pt-4 pb-3">
-            <Text className="text-2xl font-bold text-foreground">Send</Text>
-            <View className="flex-1 items-end">
-              <Pressable onPress={handleScanPress}>
-                <Icon name="scan" size={28} color={iconColor} />
-              </Pressable>
-            </View>
-          </View>
-          <ScrollView
-            className="flex-1"
-            showsVerticalScrollIndicator={false}
-            keyboardShouldPersistTaps="handled"
-            contentContainerStyle={{
-              paddingBottom: Math.max(bottomTabBarHeight, 20) + 112,
-            }}
-          >
-            <View className="px-5 pb-8">
-              <View className="pt-2">
-                <Text className="text-[11px] font-semibold uppercase tracking-[3px] text-muted-foreground">
-                  Send Bitcoin
-                </Text>
-                <Text className="mt-2 max-w-[320px] text-base leading-6 text-muted-foreground">
-                  Paste a destination, choose the payment rail when needed, and confirm before
-                  sending.
-                </Text>
-              </View>
-
-              <View className="mt-5">
-                <View className="flex-row items-start justify-end gap-4">
-                  <View className="flex-1">
-                    {canSendMax ? (
-                      <Pressable
-                        accessibilityRole="button"
-                        accessibilityLabel="Send maximum amount"
-                        onPress={handleMaxSend}
-                        className="self-start rounded-full border border-border px-4 py-2"
-                        style={{
-                          backgroundColor: isMaxSend
-                            ? `${COLORS.BITCOIN_ORANGE}20`
-                            : `${colors.card}CC`,
-                          borderColor: isMaxSend
-                            ? COLORS.BITCOIN_ORANGE
-                            : `${colors.mutedForeground}26`,
-                        }}
-                      >
-                        <Text
-                          className="text-xs font-bold tracking-[2px]"
-                          style={{
-                            color: isMaxSend ? COLORS.BITCOIN_ORANGE : colors.foreground,
-                          }}
-                        >
-                          MAX
-                        </Text>
-                      </Pressable>
-                    ) : null}
-                  </View>
-                  <CurrencyToggle onPress={toggleCurrency} disabled={!!parsedAmount || isMaxSend} />
-                </View>
-
-                <View className="mt-3 items-center">
-                  <View className="h-[64px] justify-center">
-                    <View className="self-center">
-                      <Pressable onPress={focusAmountInput} disabled={!isAmountEditable}>
-                        <View className="flex-row items-center justify-center">
-                          {amountPrefix ? (
-                            <Text className="mr-3 text-[46px] font-bold leading-[52px] text-foreground">
-                              {amountPrefix}
-                            </Text>
-                          ) : null}
-                          <Text
-                            className={`text-[46px] font-bold leading-[52px] ${
-                              isAmountEditable ? "text-foreground" : "text-foreground/70"
-                            }`}
-                          >
-                            {displayAmount}
-                          </Text>
-                          <BlinkingCaret
-                            color={COLORS.BITCOIN_ORANGE}
-                            height={40}
-                            visible={isAmountFocused && isAmountEditable}
-                          />
-                          {amountSuffix ? (
-                            <Text className="ml-3 text-2xl font-bold text-muted-foreground">
-                              {amountSuffix}
-                            </Text>
-                          ) : null}
-                        </View>
-                      </Pressable>
-                    </View>
-
-                    <TextInput
-                      ref={amountInputRef}
-                      placeholder=""
-                      keyboardType="numeric"
-                      value={amount}
-                      onChangeText={setAmount}
-                      editable={isAmountEditable}
-                      autoFocus={false}
-                      onFocus={() => setIsAmountFocused(true)}
-                      onBlur={() => setIsAmountFocused(false)}
-                      maxLength={12}
-                      selectionColor={colors.foreground}
-                      style={{
-                        position: "absolute",
-                        opacity: 0,
-                        width: 1,
-                        height: 1,
-                      }}
-                    />
-                  </View>
-
-                  <Text className="mt-3 text-lg font-medium text-muted-foreground">
-                    {isMaxSend
-                      ? selectedOnchainSource === "offchain"
-                        ? "Full Ark balance"
-                        : selectedOnchainSource === "onchain"
-                          ? "Full onchain balance"
-                          : "Choose the balance to sweep on confirmation"
-                      : parsedAmount
-                        ? `≈ ${
-                            btcPrice
-                              ? formatFiatAmount(
-                                  satsToFiat(parsedAmount, btcPrice, fiatCurrency),
-                                  fiatCurrency,
-                                )
-                              : formatFiatAmount("0.00", fiatCurrency)
-                          }`
-                        : currency === "SATS"
-                          ? `≈ ${
-                              btcPrice && amountSat && !isNaN(amountSat)
-                                ? formatFiatAmount(
-                                    satsToFiat(amountSat, btcPrice, fiatCurrency),
-                                    fiatCurrency,
-                                  )
-                                : formatFiatAmount("0.00", fiatCurrency)
-                            }`
-                          : `≈ ${!isNaN(amountSat) && amount ? formatBitcoinAmount(amountSat) : formatBitcoinAmount(0)}`}
-                  </Text>
-                </View>
-              </View>
-
-              <View className="mt-7 border-t border-border/60 pt-5">
-                <Text className="text-sm font-semibold uppercase tracking-[2px] text-muted-foreground">
-                  Destination
-                </Text>
-
-                <View
-                  className="mt-4 rounded-[22px] border px-4 py-3"
-                  style={{
-                    borderColor: isDestinationFocused
-                      ? COLORS.BITCOIN_ORANGE
-                      : `${colors.mutedForeground}26`,
-                    backgroundColor: `${colors.card}CC`,
-                  }}
-                >
-                  <View className="flex-row items-center gap-3">
-                    {destination && !isDestinationFocused ? (
-                      <Pressable className="flex-1" onPress={focusDestinationInput}>
-                        <Text
-                          className="text-base text-foreground"
-                          numberOfLines={1}
-                          ellipsizeMode="middle"
-                        >
-                          {destination}
-                        </Text>
-                      </Pressable>
-                    ) : (
-                      <TextInput
-                        ref={destinationInputRef}
-                        className="min-h-9 flex-1 text-base text-foreground"
-                        placeholder="Address, invoice, offer, or lightning address"
-                        placeholderTextColor={colors.mutedForeground}
-                        keyboardType="email-address"
-                        autoCorrect={false}
-                        autoCapitalize="none"
-                        value={destination}
-                        onChangeText={setDestination}
-                        onFocus={() => setIsDestinationFocused(true)}
-                        onBlur={() => setIsDestinationFocused(false)}
-                        style={{ minWidth: 0, flexShrink: 1 }}
-                      />
-                    )}
-                    <TouchableOpacity
-                      onPress={handlePaste}
-                      className="rounded-full px-3 py-2"
-                      style={{ backgroundColor: `${colors.foreground}0D` }}
-                    >
-                      <Text className="text-sm font-semibold text-foreground">Paste</Text>
-                    </TouchableOpacity>
-                  </View>
-                </View>
-
-                {isDestinationFocused && lightningAddressSuggestions.length > 0 && (
-                  <View
-                    className="mt-3 overflow-hidden rounded-[18px] border"
-                    style={{
-                      borderColor: `${colors.mutedForeground}24`,
-                      backgroundColor: colors.card,
-                    }}
-                  >
-                    {lightningAddressSuggestions.map((suggestion, index) => (
-                      <Pressable
-                        key={suggestion}
-                        className={`flex-row items-center gap-3 px-4 py-3 ${
-                          index < lightningAddressSuggestions.length - 1
-                            ? "border-b border-border/60"
-                            : ""
-                        }`}
-                        onPress={() => {
-                          handleSelectLightningAddressSuggestion(suggestion);
-                          Keyboard.dismiss();
-                        }}
-                      >
-                        <View
-                          className="h-8 w-8 items-center justify-center rounded-full"
-                          style={{ backgroundColor: `${COLORS.BITCOIN_ORANGE}18` }}
-                        >
-                          <Icon name="flash-outline" size={15} color={COLORS.BITCOIN_ORANGE} />
-                        </View>
-                        <View className="min-w-0 flex-1">
-                          <Text
-                            className="text-[15px] font-semibold text-foreground"
-                            numberOfLines={1}
-                            ellipsizeMode="middle"
-                          >
-                            {suggestion}
-                          </Text>
-                        </View>
-                      </Pressable>
-                    ))}
-                  </View>
-                )}
-                {!bip321Data ? (
-                  <View className="mt-4 rounded-[20px] border border-border/60 bg-card/70 px-4 py-3">
-                    <TextInput
-                      className="text-base text-foreground"
-                      placeholder="Add a note (optional)"
-                      placeholderTextColor={colors.mutedForeground}
-                      value={comment}
-                      onChangeText={setComment}
-                    />
-                  </View>
-                ) : null}
-              </View>
-            </View>
-          </ScrollView>
-
-          <View
-            className="border-t border-border/50 bg-background px-5 pt-4"
-            style={{ paddingBottom: Math.max(bottomTabBarHeight, 20) + 8 }}
-          >
-            <View className="flex-row items-center gap-3">
-              {destination ? (
-                <Button onPress={handleClear} variant="outline" className="flex-1 rounded-2xl">
-                  <Text className="font-semibold">Clear</Text>
-                </Button>
-              ) : null}
-              <Button
-                onPress={handleSend}
-                disabled={!destination || isSending}
-                className="flex-1 rounded-2xl py-4"
-                style={{ backgroundColor: COLORS.BITCOIN_ORANGE }}
-              >
-                <Text className="font-bold" style={{ color: "#1a1a1a" }}>
-                  {isSending ? "Sending..." : "Send"}
-                </Text>
-              </Button>
-            </View>
-          </View>
-        </View>
-      </TouchableWithoutFeedback>
+      {stage === "recipient" ? (
+        <SendRecipientStage
+          amountSat={isMaxSend ? maxSendAmountSat : amountSat}
+          destination={destination}
+          destinationType={destinationType}
+          bip321Data={bip321Data}
+          suggestions={lightningAddressSuggestions}
+          error={recipientError}
+          comment={comment}
+          commentAllowed={commentAllowed}
+          noteUsesLightning={noteUsesLightning}
+          isResolving={isResolvingRecipient}
+          onBack={handleStageBack}
+          onDestinationChange={setDestination}
+          onSelectSuggestion={handleSelectLightningAddressSuggestion}
+          onCommentChange={setComment}
+          onPaste={pasteDestination}
+          onScan={handleScanPress}
+          onContinue={handleRecipientContinue}
+        />
+      ) : (
+        <SendAmountStage
+          amount={amount}
+          amountSat={amountSat}
+          currency={currency}
+          fiatCurrency={fiatCurrency}
+          btcPrice={btcPrice}
+          arkBalanceSat={offchainWalletBalance}
+          onchainBalanceSat={onchainWalletBalance}
+          error={amountError}
+          onAmountChange={setAmount}
+          onToggleCurrency={toggleCurrency}
+          onContinue={handleAmountContinue}
+          onMax={() => {
+            handleMaxSend();
+            startRecipientEntry();
+          }}
+          onPaste={pasteDestination}
+          onScan={handleScanPress}
+        />
+      )}
 
       <AppBottomSheet isOpen={showConfirmation} onClose={handleCancelConfirmation} scrollable>
         <SendConfirmation
@@ -434,10 +146,10 @@ const SendScreen = () => {
           amountNote={
             isMaxSend
               ? selectedOnchainSource === "offchain"
-                ? "Sweeps the full Ark balance after the offboarding fee."
+                ? "Estimated amount after offboarding fees"
                 : selectedOnchainSource === "onchain"
-                  ? "Sweeps the full onchain balance; the miner fee is deducted when the transaction is built."
-                  : "Choose which balance to sweep."
+                  ? "The final miner fee is calculated when the transaction is built"
+                  : "Choose the balance to sweep"
               : null
           }
           destinationType={destinationType}
@@ -473,14 +185,14 @@ const SendScreen = () => {
       </AppBottomSheet>
 
       <AppBottomSheet isOpen={showSuccess} onClose={handleCloseSuccess} scrollable>
-        {parsedResult && (
+        {parsedResult ? (
           <SendSuccessBottomSheet
             parsedResult={parsedResult}
             handleDone={handleDone}
             btcPrice={btcPrice}
             fiatCurrency={fiatCurrency}
           />
-        )}
+        ) : null}
       </AppBottomSheet>
     </NoahSafeAreaView>
   );

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -9,6 +9,7 @@ import { SendSuccessBottomSheet } from "~/components/SendSuccessBottomSheet";
 import { SendAmountStage } from "~/components/send/SendAmountStage";
 import { SendChoiceStage, type SendChoiceOption } from "~/components/send/SendChoiceStage";
 import { SendRecipientStage } from "~/components/send/SendRecipientStage";
+import { SendStageTransition } from "~/components/send/SendStageTransition";
 import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
 import { useSendScreen } from "~/hooks/useSendScreen";
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
@@ -20,6 +21,7 @@ const SendScreen = () => {
   const formatBitcoinAmount = useBitcoinAmountFormatter();
   const {
     stage,
+    stageDirection,
     canGoBack,
     amount,
     amountSat,
@@ -164,73 +166,77 @@ const SendScreen = () => {
 
   return (
     <NoahSafeAreaView className="flex-1 bg-background">
-      {stage === "method" ? (
-        <SendChoiceStage
-          title="How should Noah pay?"
-          description="Noah recommends the first available method. You can choose another method supplied by this request."
-          options={railChoices}
-          value={selectedRail}
-          onBack={handleStageBack}
-          onChange={setSelectedRail}
-          onContinue={handleRailContinue}
-          testIDPrefix="send-method"
-        />
-      ) : stage === "source" ? (
-        <SendChoiceStage
-          title={isMaxSend ? "Which balance should Noah empty?" : "Which balance should Noah use?"}
-          description={
-            isMaxSend
-              ? "MAX sends one balance in full. The miner fee is deducted from the final amount."
-              : "Choose the balance that will fund this on-chain payment."
-          }
-          options={sourceChoices}
-          value={selectedOnchainSource}
-          onBack={handleStageBack}
-          onChange={setSelectedOnchainSource}
-          onContinue={handleSourceContinue}
-          testIDPrefix="send-source"
-        />
-      ) : stage === "recipient" ? (
-        <SendRecipientStage
-          amountSat={isMaxSend ? maxSendAmountSat : amountSat}
-          destination={destination}
-          destinationType={destinationType}
-          bip321Data={bip321Data}
-          suggestions={lightningAddressSuggestions}
-          error={recipientError}
-          comment={comment}
-          commentAllowed={commentAllowed}
-          noteUsesLightning={noteUsesLightning}
-          isResolving={isResolvingRecipient}
-          onBack={handleStageBack}
-          onDestinationChange={setDestination}
-          onSelectSuggestion={handleSelectLightningAddressSuggestion}
-          onCommentChange={setComment}
-          onPaste={pasteDestination}
-          onScan={handleScanPress}
-          onContinue={handleRecipientContinue}
-        />
-      ) : (
-        <SendAmountStage
-          amount={amount}
-          amountSat={amountSat}
-          currency={currency}
-          fiatCurrency={fiatCurrency}
-          btcPrice={btcPrice}
-          arkBalanceSat={offchainWalletBalance}
-          onchainBalanceSat={onchainWalletBalance}
-          error={amountError}
-          isAmountEditable={isAmountEditable}
-          canSendMax={canSendMax}
-          onBack={canGoBack ? handleStageBack : undefined}
-          onAmountChange={setAmount}
-          onToggleCurrency={toggleCurrency}
-          onContinue={handleAmountContinue}
-          onMax={handleMaxSend}
-          onPaste={pasteDestination}
-          onScan={handleScanPress}
-        />
-      )}
+      <SendStageTransition direction={stageDirection} stage={stage}>
+        {stage === "method" ? (
+          <SendChoiceStage
+            title="How should Noah pay?"
+            description="Noah recommends the first available method. You can choose another method supplied by this request."
+            options={railChoices}
+            value={selectedRail}
+            onBack={handleStageBack}
+            onChange={setSelectedRail}
+            onContinue={handleRailContinue}
+            testIDPrefix="send-method"
+          />
+        ) : stage === "source" ? (
+          <SendChoiceStage
+            title={
+              isMaxSend ? "Which balance should Noah empty?" : "Which balance should Noah use?"
+            }
+            description={
+              isMaxSend
+                ? "MAX sends one balance in full. The miner fee is deducted from the final amount."
+                : "Choose the balance that will fund this on-chain payment."
+            }
+            options={sourceChoices}
+            value={selectedOnchainSource}
+            onBack={handleStageBack}
+            onChange={setSelectedOnchainSource}
+            onContinue={handleSourceContinue}
+            testIDPrefix="send-source"
+          />
+        ) : stage === "recipient" ? (
+          <SendRecipientStage
+            amountSat={isMaxSend ? maxSendAmountSat : amountSat}
+            destination={destination}
+            destinationType={destinationType}
+            bip321Data={bip321Data}
+            suggestions={lightningAddressSuggestions}
+            error={recipientError}
+            comment={comment}
+            commentAllowed={commentAllowed}
+            noteUsesLightning={noteUsesLightning}
+            isResolving={isResolvingRecipient}
+            onBack={handleStageBack}
+            onDestinationChange={setDestination}
+            onSelectSuggestion={handleSelectLightningAddressSuggestion}
+            onCommentChange={setComment}
+            onPaste={pasteDestination}
+            onScan={handleScanPress}
+            onContinue={handleRecipientContinue}
+          />
+        ) : (
+          <SendAmountStage
+            amount={amount}
+            amountSat={amountSat}
+            currency={currency}
+            fiatCurrency={fiatCurrency}
+            btcPrice={btcPrice}
+            arkBalanceSat={offchainWalletBalance}
+            onchainBalanceSat={onchainWalletBalance}
+            error={amountError}
+            isAmountEditable={isAmountEditable}
+            canSendMax={canSendMax}
+            onBack={canGoBack ? handleStageBack : undefined}
+            onAmountChange={setAmount}
+            onToggleCurrency={toggleCurrency}
+            onContinue={handleAmountContinue}
+            onMax={handleMaxSend}
+            onPaste={pasteDestination}
+            onScan={handleScanPress}
+          />
+        )}
+      </SendStageTransition>
 
       <AppBottomSheet
         isOpen={showConfirmation}

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -14,7 +14,12 @@ import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
 import { useSendScreen } from "~/hooks/useSendScreen";
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 import type { OnchainSendSource } from "~/lib/paymentsApi";
-import { getOnchainSourceLabel, getSendRailLabel, type SendRail } from "~/lib/sendFlow";
+import {
+  getDestinationLabel,
+  getOnchainSourceLabel,
+  getSendRailLabel,
+  type SendRail,
+} from "~/lib/sendFlow";
 
 const SendScreen = () => {
   const isFocused = useIsFocused();
@@ -29,6 +34,7 @@ const SendScreen = () => {
     amountError,
     isAmountEditable,
     canSendMax,
+    canClear,
     currency,
     fiatCurrency,
     btcPrice,
@@ -47,7 +53,9 @@ const SendScreen = () => {
     commentAllowed,
     noteUsesLightning,
     isResolvingRecipient,
-    startRecipientEntry,
+    handleImportedDestination,
+    handleEditRecipient,
+    handleClear,
     handleStageBack,
     handleAmountContinue,
     handleRecipientContinue,
@@ -96,22 +104,13 @@ const SendScreen = () => {
     }
   }, [isFocused, setShowCamera, showCamera]);
 
-  const applyPastedDestination = (value: string) => {
-    if (!value.trim()) {
-      return;
-    }
-
-    setDestination(value);
-    startRecipientEntry();
-  };
-
   const pasteDestination = async () => {
-    applyPastedDestination(await Clipboard.getStringAsync());
+    handleImportedDestination(await Clipboard.getStringAsync());
   };
 
   const pasteDestinationFromScanner = (value: string) => {
     setShowCamera(false);
-    applyPastedDestination(value);
+    handleImportedDestination(value);
   };
 
   if (showCamera) {
@@ -163,6 +162,10 @@ const SendScreen = () => {
           : "Insufficient confirmed balance",
     },
   ];
+  const recipientLabel =
+    destinationType === "bip321"
+      ? paymentRailOptions.map(getSendRailLabel).join(" · ")
+      : getDestinationLabel(destinationType);
 
   return (
     <NoahSafeAreaView className="flex-1 bg-background">
@@ -227,10 +230,15 @@ const SendScreen = () => {
             error={amountError}
             isAmountEditable={isAmountEditable}
             canSendMax={canSendMax}
+            canClear={canClear}
+            recipient={recipientLabel ? destination : null}
+            recipientLabel={recipientLabel}
             onBack={canGoBack ? handleStageBack : undefined}
             onAmountChange={setAmount}
             onToggleCurrency={toggleCurrency}
             onContinue={handleAmountContinue}
+            onClear={handleClear}
+            onEditRecipient={handleEditRecipient}
             onMax={handleMaxSend}
             onPaste={pasteDestination}
             onScan={handleScanPress}

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -7,12 +7,17 @@ import { QRCodeScanner } from "~/components/QRCodeScanner";
 import { SendConfirmation } from "~/components/SendConfirmation";
 import { SendSuccessBottomSheet } from "~/components/SendSuccessBottomSheet";
 import { SendAmountStage } from "~/components/send/SendAmountStage";
+import { SendChoiceStage, type SendChoiceOption } from "~/components/send/SendChoiceStage";
 import { SendRecipientStage } from "~/components/send/SendRecipientStage";
 import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
 import { useSendScreen } from "~/hooks/useSendScreen";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
+import type { OnchainSendSource } from "~/lib/paymentsApi";
+import type { SendRail } from "~/lib/sendFlow";
 
 const SendScreen = () => {
   const isFocused = useIsFocused();
+  const formatBitcoinAmount = useBitcoinAmountFormatter();
   const {
     stage,
     amount,
@@ -41,6 +46,8 @@ const SendScreen = () => {
     handleStageBack,
     handleAmountContinue,
     handleRecipientContinue,
+    handleRailContinue,
+    handleSourceContinue,
     handleMaxSend,
     parsedResult,
     handleConfirmSend,
@@ -52,7 +59,10 @@ const SendScreen = () => {
     handleScanPress,
     codeScanner,
     selectedPaymentMethod,
-    setSelectedPaymentMethod,
+    paymentRailOptions,
+    railAvailability,
+    selectedRail,
+    setSelectedRail,
     onchainSourceOptions,
     selectedOnchainSource,
     setSelectedOnchainSource,
@@ -95,9 +105,75 @@ const SendScreen = () => {
     return <QRCodeScanner codeScanner={codeScanner} onClose={() => setShowCamera(false)} />;
   }
 
+  const railChoices: SendChoiceOption<SendRail>[] = paymentRailOptions.map((rail) => ({
+    value: rail,
+    title: rail === "ark" ? "Ark" : rail === "lightning" ? "Lightning" : "On-chain",
+    subtitle:
+      rail === "ark"
+        ? "Direct Ark payment with the lowest latency"
+        : rail === "lightning"
+          ? "Pay through the Lightning Network"
+          : "Broadcast a Bitcoin transaction",
+    unavailableReason: railAvailability[rail]
+      ? undefined
+      : rail === "onchain"
+        ? "Neither balance can cover this amount"
+        : "Insufficient Ark balance",
+  }));
+  const sourceChoices: SendChoiceOption<OnchainSendSource>[] = [
+    {
+      value: "offchain",
+      title: "Ark balance",
+      subtitle: "Send on-chain by offboarding from Ark",
+      detail: formatBitcoinAmount(offchainWalletBalance),
+      unavailableReason: onchainSourceOptions.includes("offchain")
+        ? undefined
+        : isMaxSend
+          ? "No Ark balance available"
+          : "Insufficient Ark balance",
+    },
+    {
+      value: "onchain",
+      title: "On-chain wallet",
+      subtitle: "Spend confirmed on-chain funds",
+      detail: formatBitcoinAmount(onchainWalletBalance),
+      unavailableReason: onchainSourceOptions.includes("onchain")
+        ? undefined
+        : isMaxSend
+          ? "No confirmed on-chain balance available"
+          : "Insufficient confirmed balance",
+    },
+  ];
+
   return (
     <NoahSafeAreaView className="flex-1 bg-background">
-      {stage === "recipient" ? (
+      {stage === "method" ? (
+        <SendChoiceStage
+          title="How should Noah pay?"
+          description="Noah recommends the first available method. You can choose another method supplied by this request."
+          options={railChoices}
+          value={selectedRail}
+          onBack={handleStageBack}
+          onChange={setSelectedRail}
+          onContinue={handleRailContinue}
+          testIDPrefix="send-method"
+        />
+      ) : stage === "source" ? (
+        <SendChoiceStage
+          title={isMaxSend ? "Which balance should Noah empty?" : "Which balance should Noah use?"}
+          description={
+            isMaxSend
+              ? "MAX sends one balance in full. The miner fee is deducted from the final amount."
+              : "Choose the balance that will fund this on-chain payment."
+          }
+          options={sourceChoices}
+          value={selectedOnchainSource}
+          onBack={handleStageBack}
+          onChange={setSelectedOnchainSource}
+          onContinue={handleSourceContinue}
+          testIDPrefix="send-source"
+        />
+      ) : stage === "recipient" ? (
         <SendRecipientStage
           amountSat={isMaxSend ? maxSendAmountSat : amountSat}
           destination={destination}
@@ -130,10 +206,7 @@ const SendScreen = () => {
           onAmountChange={setAmount}
           onToggleCurrency={toggleCurrency}
           onContinue={handleAmountContinue}
-          onMax={() => {
-            handleMaxSend();
-            startRecipientEntry();
-          }}
+          onMax={handleMaxSend}
           onPaste={pasteDestination}
           onScan={handleScanPress}
         />
@@ -158,12 +231,8 @@ const SendScreen = () => {
           fiatCurrency={fiatCurrency}
           bip321Data={bip321Data}
           selectedPaymentMethod={selectedPaymentMethod}
-          onSelectPaymentMethod={setSelectedPaymentMethod}
-          onchainSourceOptions={onchainSourceOptions}
+          selectedRail={selectedRail}
           selectedOnchainSource={selectedOnchainSource}
-          onSelectOnchainSource={setSelectedOnchainSource}
-          onchainWalletBalance={onchainWalletBalance}
-          offchainWalletBalance={offchainWalletBalance}
           onConfirm={handleConfirmSend}
           onCancel={handleCancelConfirmation}
           isConfirmDisabled={

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -20,6 +20,7 @@ const SendScreen = () => {
   const formatBitcoinAmount = useBitcoinAmountFormatter();
   const {
     stage,
+    canGoBack,
     amount,
     amountSat,
     setAmount,
@@ -207,6 +208,7 @@ const SendScreen = () => {
           error={amountError}
           isAmountEditable={isAmountEditable}
           canSendMax={canSendMax}
+          onBack={canGoBack ? handleStageBack : undefined}
           onAmountChange={setAmount}
           onToggleCurrency={toggleCurrency}
           onContinue={handleAmountContinue}

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -13,7 +13,7 @@ import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
 import { useSendScreen } from "~/hooks/useSendScreen";
 import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 import type { OnchainSendSource } from "~/lib/paymentsApi";
-import type { SendRail } from "~/lib/sendFlow";
+import { getOnchainSourceLabel, getSendRailLabel, type SendRail } from "~/lib/sendFlow";
 
 const SendScreen = () => {
   const isFocused = useIsFocused();
@@ -84,6 +84,7 @@ const SendScreen = () => {
     confirmationError,
     isMaxSend,
     maxSendAmountSat,
+    confirmationAmountSat,
   } = useSendScreen();
 
   useEffect(() => {
@@ -108,7 +109,7 @@ const SendScreen = () => {
 
   const railChoices: SendChoiceOption<SendRail>[] = paymentRailOptions.map((rail) => ({
     value: rail,
-    title: rail === "ark" ? "Ark" : rail === "lightning" ? "Lightning" : "On-chain",
+    title: getSendRailLabel(rail),
     subtitle:
       rail === "ark"
         ? "Direct Ark payment with the lowest latency"
@@ -124,7 +125,7 @@ const SendScreen = () => {
   const sourceChoices: SendChoiceOption<OnchainSendSource>[] = [
     {
       value: "offchain",
-      title: "Ark balance",
+      title: getOnchainSourceLabel("offchain"),
       subtitle: "Send on-chain by offboarding from Ark",
       detail: formatBitcoinAmount(offchainWalletBalance),
       unavailableReason: onchainSourceOptions.includes("offchain")
@@ -135,7 +136,7 @@ const SendScreen = () => {
     },
     {
       value: "onchain",
-      title: "On-chain wallet",
+      title: getOnchainSourceLabel("onchain"),
       subtitle: "Spend confirmed on-chain funds",
       detail: formatBitcoinAmount(onchainWalletBalance),
       unavailableReason: onchainSourceOptions.includes("onchain")
@@ -223,16 +224,19 @@ const SendScreen = () => {
       >
         <SendConfirmation
           destination={destination}
-          amount={isMaxSend ? maxSendAmountSat : amountSat}
+          amount={confirmationAmountSat}
           amountNote={
             isMaxSend
               ? selectedOnchainSource === "offchain"
-                ? "Estimated amount after offboarding fees"
+                ? feeEstimate
+                  ? "Estimated amount after offboarding fees"
+                  : "The final offboarding fee is deducted from the amount"
                 : selectedOnchainSource === "onchain"
                   ? "The final miner fee is calculated when the transaction is built"
                   : "Choose the balance to sweep"
               : null
           }
+          isMaxAmount={isMaxSend}
           destinationType={destinationType}
           comment={comment}
           btcPrice={btcPrice}

--- a/client/src/screens/SendScreen.tsx
+++ b/client/src/screens/SendScreen.tsx
@@ -24,6 +24,8 @@ const SendScreen = () => {
     amountSat,
     setAmount,
     amountError,
+    isAmountEditable,
+    canSendMax,
     currency,
     fiatCurrency,
     btcPrice,
@@ -73,7 +75,6 @@ const SendScreen = () => {
     isLightningAddressPaymentRouteResolutionRequired,
     showConfirmation,
     showSuccess,
-    handleCloseSuccess,
     feeEstimate,
     isEstimatingFee,
     feeEstimateError,
@@ -203,6 +204,8 @@ const SendScreen = () => {
           arkBalanceSat={offchainWalletBalance}
           onchainBalanceSat={onchainWalletBalance}
           error={amountError}
+          isAmountEditable={isAmountEditable}
+          canSendMax={canSendMax}
           onAmountChange={setAmount}
           onToggleCurrency={toggleCurrency}
           onContinue={handleAmountContinue}
@@ -212,7 +215,12 @@ const SendScreen = () => {
         />
       )}
 
-      <AppBottomSheet isOpen={showConfirmation} onClose={handleCancelConfirmation} scrollable>
+      <AppBottomSheet
+        isOpen={showConfirmation}
+        onClose={handleCancelConfirmation}
+        scrollable
+        dismissible={!isSending}
+      >
         <SendConfirmation
           destination={destination}
           amount={isMaxSend ? maxSendAmountSat : amountSat}
@@ -253,7 +261,7 @@ const SendScreen = () => {
         />
       </AppBottomSheet>
 
-      <AppBottomSheet isOpen={showSuccess} onClose={handleCloseSuccess} scrollable>
+      <AppBottomSheet isOpen={showSuccess} onClose={handleDone} scrollable>
         {parsedResult ? (
           <SendSuccessBottomSheet
             parsedResult={parsedResult}

--- a/client/tests/unit/fiatCurrency.test.js
+++ b/client/tests/unit/fiatCurrency.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("noah-tools", () => ({
+  getAppVariant: () => "signet",
+}));
+
+const { fiatToSats } = await import("../../src/lib/fiatCurrency");
+
+describe("fiat-to-sats conversion", () => {
+  test("treats an empty fiat amount as zero", () => {
+    expect(fiatToSats(Number.parseFloat(""), 100_000)).toBe(0);
+  });
+});

--- a/client/tests/unit/sendFlow.test.js
+++ b/client/tests/unit/sendFlow.test.js
@@ -4,6 +4,8 @@ import {
   canAddRecipientNote,
   getBip321Rails,
   getBip321MethodForRail,
+  getDestinationLabel,
+  getDestinationRails,
   getNextSendStage,
   getRecommendedRail,
   isMaxCompatibleDestination,
@@ -19,6 +21,19 @@ describe("send payment rail choices", () => {
         arkAddress: "ark1destination",
       }),
     ).toEqual(["ark", "lightning", "onchain"]);
+  });
+
+  test("maps pasted destinations to their available rails and display labels", () => {
+    expect(getDestinationRails("ark", null)).toEqual(["ark"]);
+    expect(getDestinationRails("onchain", null)).toEqual(["onchain"]);
+    expect(
+      getDestinationRails("bip321", {
+        onchainAddress: "bc1qdestination",
+        arkAddress: "ark1destination",
+      }),
+    ).toEqual(["ark", "onchain"]);
+    expect(getDestinationLabel("bip321")).toBe("Bitcoin payment request");
+    expect(getDestinationLabel(null)).toBeNull();
   });
 
   test("uses an invoice before an offer for the Lightning rail", () => {
@@ -69,6 +84,28 @@ describe("MAX recipient compatibility", () => {
 });
 
 describe("send stage progression", () => {
+  test("keeps a confirmed amountless recipient on the amount composer", () => {
+    const importedRecipient = {
+      entry: "recipient-first",
+      recipientConfirmed: true,
+      railConfirmed: false,
+      sourceConfirmed: false,
+      rails: ["ark"],
+      selectedRail: "ark",
+      selectedRailAvailable: false,
+      sourceOptions: [],
+    };
+
+    expect(getNextSendStage({ ...importedRecipient, amountConfirmed: false })).toBe("amount");
+    expect(
+      getNextSendStage({
+        ...importedRecipient,
+        amountConfirmed: true,
+        selectedRailAvailable: true,
+      }),
+    ).toBe("review");
+  });
+
   test("walks an amount-first payment through each unresolved decision", () => {
     const baseProgress = {
       entry: "amount-first",

--- a/client/tests/unit/sendFlow.test.js
+++ b/client/tests/unit/sendFlow.test.js
@@ -5,6 +5,7 @@ import {
   getBip321Rails,
   getBip321MethodForRail,
   getNextSendStage,
+  getRecommendedRail,
   isMaxCompatibleDestination,
 } from "../../src/lib/sendFlow";
 
@@ -28,6 +29,23 @@ describe("send payment rail choices", () => {
       }),
     ).toBe("lightning");
     expect(getBip321MethodForRail("lightning", { offer: "lno1offer" })).toBe("offer");
+  });
+
+  test("recommends the first eligible rail without hiding unavailable rails", () => {
+    expect(
+      getRecommendedRail(["ark", "lightning", "onchain"], {
+        ark: false,
+        lightning: false,
+        onchain: true,
+      }),
+    ).toBe("onchain");
+    expect(
+      getRecommendedRail(["ark", "lightning", "onchain"], {
+        ark: false,
+        lightning: false,
+        onchain: false,
+      }),
+    ).toBe("ark");
   });
 });
 
@@ -113,6 +131,21 @@ describe("send stage progression", () => {
         rails: ["onchain"],
         selectedRail: "onchain",
         sourceOptions: ["offchain", "onchain"],
+      }),
+    ).toBe("source");
+  });
+
+  test("shows funding sources when no balance can cover an on-chain payment", () => {
+    expect(
+      getNextSendStage({
+        entry: "amount-first",
+        amountConfirmed: true,
+        recipientConfirmed: true,
+        railConfirmed: true,
+        sourceConfirmed: false,
+        rails: ["onchain"],
+        selectedRail: "onchain",
+        sourceOptions: [],
       }),
     ).toBe("source");
   });

--- a/client/tests/unit/sendFlow.test.js
+++ b/client/tests/unit/sendFlow.test.js
@@ -135,6 +135,21 @@ describe("send stage progression", () => {
     ).toBe("source");
   });
 
+  test("reviews MAX after its source and recipient are confirmed", () => {
+    expect(
+      getNextSendStage({
+        entry: "max",
+        amountConfirmed: true,
+        recipientConfirmed: true,
+        railConfirmed: true,
+        sourceConfirmed: true,
+        rails: ["onchain"],
+        selectedRail: "onchain",
+        sourceOptions: ["offchain", "onchain"],
+      }),
+    ).toBe("review");
+  });
+
   test("shows funding sources when no balance can cover an on-chain payment", () => {
     expect(
       getNextSendStage({

--- a/client/tests/unit/sendFlow.test.js
+++ b/client/tests/unit/sendFlow.test.js
@@ -149,4 +149,20 @@ describe("send stage progression", () => {
       }),
     ).toBe("source");
   });
+
+  test("hard-blocks a single unavailable rail before review", () => {
+    expect(
+      getNextSendStage({
+        entry: "amount-first",
+        amountConfirmed: true,
+        recipientConfirmed: true,
+        railConfirmed: false,
+        sourceConfirmed: false,
+        rails: ["ark"],
+        selectedRail: "ark",
+        selectedRailAvailable: false,
+        sourceOptions: [],
+      }),
+    ).toBe("method");
+  });
 });

--- a/client/tests/unit/sendFlow.test.js
+++ b/client/tests/unit/sendFlow.test.js
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  canAddRecipientNote,
+  getBip321Rails,
+  getBip321MethodForRail,
+  getNextSendStage,
+  isMaxCompatibleDestination,
+} from "../../src/lib/sendFlow";
+
+describe("send payment rail choices", () => {
+  test("recommends Ark, Lightning, then on-chain and groups Lightning variants", () => {
+    expect(
+      getBip321Rails({
+        onchainAddress: "bc1qdestination",
+        offer: "lno1offer",
+        lightningInvoice: "lnbc1invoice",
+        arkAddress: "ark1destination",
+      }),
+    ).toEqual(["ark", "lightning", "onchain"]);
+  });
+
+  test("uses an invoice before an offer for the Lightning rail", () => {
+    expect(
+      getBip321MethodForRail("lightning", {
+        lightningInvoice: "lnbc1invoice",
+        offer: "lno1offer",
+      }),
+    ).toBe("lightning");
+    expect(getBip321MethodForRail("lightning", { offer: "lno1offer" })).toBe("offer");
+  });
+});
+
+describe("send recipient notes", () => {
+  test("offers a note only when a Lightning address accepts comments", () => {
+    expect(canAddRecipientNote("lnurl", 64)).toBe(true);
+    expect(canAddRecipientNote("lnurl", 0)).toBe(false);
+    expect(canAddRecipientNote("lightning", 64)).toBe(false);
+    expect(canAddRecipientNote("ark", 64)).toBe(false);
+    expect(canAddRecipientNote("onchain", 64)).toBe(false);
+  });
+});
+
+describe("MAX recipient compatibility", () => {
+  test("accepts only destinations with an on-chain payment method", () => {
+    expect(isMaxCompatibleDestination("onchain", null)).toBe(true);
+    expect(isMaxCompatibleDestination("bip321", { onchainAddress: "bc1qdestination" })).toBe(true);
+    expect(isMaxCompatibleDestination("bip321", { arkAddress: "ark1destination" })).toBe(false);
+    expect(isMaxCompatibleDestination("lightning", null)).toBe(false);
+  });
+});
+
+describe("send stage progression", () => {
+  test("walks an amount-first payment through each unresolved decision", () => {
+    const baseProgress = {
+      entry: "amount-first",
+      amountConfirmed: false,
+      recipientConfirmed: false,
+      railConfirmed: false,
+      sourceConfirmed: false,
+      rails: ["ark", "lightning", "onchain"],
+      selectedRail: "onchain",
+      sourceOptions: ["offchain", "onchain"],
+    };
+
+    expect(getNextSendStage(baseProgress)).toBe("amount");
+    expect(getNextSendStage({ ...baseProgress, amountConfirmed: true })).toBe("recipient");
+    expect(
+      getNextSendStage({ ...baseProgress, amountConfirmed: true, recipientConfirmed: true }),
+    ).toBe("method");
+    expect(
+      getNextSendStage({
+        ...baseProgress,
+        amountConfirmed: true,
+        recipientConfirmed: true,
+        railConfirmed: true,
+      }),
+    ).toBe("source");
+    expect(
+      getNextSendStage({
+        ...baseProgress,
+        amountConfirmed: true,
+        recipientConfirmed: true,
+        railConfirmed: true,
+        sourceConfirmed: true,
+      }),
+    ).toBe("review");
+  });
+
+  test("asks for a prefilled recipient before an unresolved amount", () => {
+    expect(
+      getNextSendStage({
+        entry: "recipient-first",
+        amountConfirmed: false,
+        recipientConfirmed: false,
+        railConfirmed: true,
+        sourceConfirmed: true,
+        rails: ["lightning"],
+        selectedRail: "lightning",
+        sourceOptions: [],
+      }),
+    ).toBe("recipient");
+  });
+
+  test("chooses the balance before the recipient for MAX", () => {
+    expect(
+      getNextSendStage({
+        entry: "max",
+        amountConfirmed: true,
+        recipientConfirmed: false,
+        railConfirmed: true,
+        sourceConfirmed: false,
+        rails: ["onchain"],
+        selectedRail: "onchain",
+        sourceOptions: ["offchain", "onchain"],
+      }),
+    ).toBe("source");
+  });
+});

--- a/client/tests/unit/sendUtils.test.js
+++ b/client/tests/unit/sendUtils.test.js
@@ -25,6 +25,7 @@ const { isValidDestination, parseDestination } = await import("../../src/lib/sen
 // Fixture from LDK's BOLT12 parser tests. BOLT12 uses Bech32 encoding without a checksum.
 const BOLT12_OFFER =
   "lno1pqps7sjqpgtyzm3qv4uxzmtsd3jjqer9wd3hy6tsw35k7msjzfpy7nz5yqcnygrfdej82um5wf5k2uckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg";
+const ONCHAIN_ADDRESS = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
 
 describe("BOLT12 send destinations", () => {
   test("accepts a bare BOLT12 offer", () => {
@@ -77,5 +78,17 @@ describe("BOLT12 send destinations", () => {
     expect(isValidDestination(mixedCaseOffer)).toBe(false);
     expect(isValidDestination("bitcoin:?lno=lno1not-an-offer")).toBe(false);
     expect(parseDestination("bitcoin:?lno=lno1not-an-offer").destinationType).toBeNull();
+  });
+});
+
+describe("amountless send destinations", () => {
+  test("treats a zero-amount BIP-321 request as editable", () => {
+    expect(parseDestination(`bitcoin:${ONCHAIN_ADDRESS}?amount=0`)).toEqual({
+      destinationType: "bip321",
+      isAmountEditable: true,
+      bip321: {
+        onchainAddress: ONCHAIN_ADDRESS,
+      },
+    });
   });
 });

--- a/scripts/test-send-regtest.sh
+++ b/scripts/test-send-regtest.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+maestro_command="${MAESTRO_COMMAND:-maestro}"
+simulator_id="${SIMULATOR_ID:-}"
+
+if [[ -z "$simulator_id" ]]; then
+  simulator_id="$(xcrun simctl list devices booted | awk -F '[()]' '/Booted/ { print $2; exit }')"
+fi
+if [[ -z "$simulator_id" ]]; then
+  printf 'No booted iOS simulator found.\n' >&2
+  exit 1
+fi
+
+cd "$project_root"
+
+"$maestro_command" test --udid "$simulator_id" \
+  client/.maestro/subflows/prepare-send-wallet-ios.yml
+
+simulator_ark_address="$(xcrun simctl pbpaste "$simulator_id" | tr -d '\r\n')"
+if [[ ! "$simulator_ark_address" =~ ^tark1 ]]; then
+  printf 'Expected a regtest Ark address in the simulator clipboard, got: %s\n' \
+    "$simulator_ark_address" >&2
+  exit 1
+fi
+
+printf 'Funding simulator address %s with 100000 sats from Bark.\n' "$simulator_ark_address"
+just bark send-to "$simulator_ark_address" "100000 sats"
+
+bark_ark_address="$(just bark address 2>&1 | sed -n '/^tark1/p' | tail -n 1)"
+if [[ ! "$bark_ark_address" =~ ^tark1 ]]; then
+  printf 'Could not generate a regtest Bark address.\n' >&2
+  exit 1
+fi
+
+printf 'Sending 5000 sats from the simulator to Bark address %s.\n' "$bark_ark_address"
+"$maestro_command" test --udid "$simulator_id" \
+  -e "BARK_ARK_ADDRESS=$bark_ark_address" \
+  client/.maestro/subflows/send-funded-ark.yml
+
+just bark balance

--- a/scripts/test-send-regtest.sh
+++ b/scripts/test-send-regtest.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 maestro_command="${MAESTRO_COMMAND:-maestro}"
+maestro_debug_output="${MAESTRO_DEBUG_OUTPUT:-client/maestro-debug-output/send-funded}"
 simulator_id="${SIMULATOR_ID:-}"
 
 if [[ -z "$simulator_id" ]]; then
@@ -17,7 +18,8 @@ fi
 cd "$project_root"
 
 "$maestro_command" test --udid "$simulator_id" \
-  client/.maestro/subflows/prepare-send-wallet-ios.yml
+  --debug-output "$maestro_debug_output/prepare" \
+  client/.maestro/subflows/prepare-funded-send-ios.yml
 
 simulator_ark_address="$(xcrun simctl pbpaste "$simulator_id" | tr -d '\r\n')"
 if [[ ! "$simulator_ark_address" =~ ^tark1 ]]; then
@@ -38,6 +40,7 @@ fi
 printf 'Sending 5000 sats from the simulator to Bark address %s.\n' "$bark_ark_address"
 printf '%s' "$bark_ark_address" | xcrun simctl pbcopy "$simulator_id"
 "$maestro_command" test --udid "$simulator_id" \
+  --debug-output "$maestro_debug_output/payment" \
   client/.maestro/subflows/send-funded-ark.yml
 
 just bark balance

--- a/scripts/test-send-regtest.sh
+++ b/scripts/test-send-regtest.sh
@@ -43,4 +43,16 @@ printf '%s' "$bark_ark_address" | xcrun simctl pbcopy "$simulator_id"
   --debug-output "$maestro_debug_output/payment" \
   client/.maestro/subflows/send-funded-ark.yml
 
+fixed_request_address="$(just bcli getnewaddress 2>&1 | sed -n '/^bcrt1/p' | tail -n 1)"
+if [[ ! "$fixed_request_address" =~ ^bcrt1 ]]; then
+  printf 'Could not generate a regtest Bitcoin address for the fixed-request regression.\n' >&2
+  exit 1
+fi
+
+printf 'Verifying MAX resets before pasting a fixed-amount payment request.\n'
+printf 'bitcoin:%s?amount=0.00005' "$fixed_request_address" | xcrun simctl pbcopy "$simulator_id"
+"$maestro_command" test --udid "$simulator_id" \
+  --debug-output "$maestro_debug_output/max-back-fixed-request" \
+  client/.maestro/subflows/send-max-back-fixed-request.yml
+
 just bark balance

--- a/scripts/test-send-regtest.sh
+++ b/scripts/test-send-regtest.sh
@@ -36,8 +36,8 @@ if [[ ! "$bark_ark_address" =~ ^tark1 ]]; then
 fi
 
 printf 'Sending 5000 sats from the simulator to Bark address %s.\n' "$bark_ark_address"
+printf '%s' "$bark_ark_address" | xcrun simctl pbcopy "$simulator_id"
 "$maestro_command" test --udid "$simulator_id" \
-  -e "BARK_ARK_ADDRESS=$bark_ark_address" \
   client/.maestro/subflows/send-funded-ark.yml
 
 just bark balance

--- a/scripts/test-send-regtest.sh
+++ b/scripts/test-send-regtest.sh
@@ -60,4 +60,16 @@ printf 'bitcoin:%s?amount=0.00005' "$fixed_request_address" | xcrun simctl pbcop
   --debug-output "$maestro_debug_output/max-back-fixed-request" \
   client/.maestro/subflows/send-max-back-fixed-request.yml
 
+amountless_request_address="$(just bcli getnewaddress 2>&1 | sed -n '/^bcrt1/p' | tail -n 1)"
+if [[ ! "$amountless_request_address" =~ ^bcrt1 ]]; then
+  printf 'Could not generate a regtest Bitcoin address for the amountless-request regression.\n' >&2
+  exit 1
+fi
+
+printf 'Verifying a zero-amount BIP-321 request stays on the amount composer.\n'
+printf 'bitcoin:%s?amount=0' "$amountless_request_address" | xcrun simctl pbcopy "$simulator_id"
+"$maestro_command" test --udid "$simulator_id" \
+  --debug-output "$maestro_debug_output/amountless-request" \
+  client/.maestro/subflows/send-amountless-request.yml
+
 just bark balance

--- a/scripts/test-send-regtest.sh
+++ b/scripts/test-send-regtest.sh
@@ -27,7 +27,7 @@ if [[ ! "$simulator_ark_address" =~ ^tark1 ]]; then
 fi
 
 printf 'Funding simulator address %s with 100000 sats from Bark.\n' "$simulator_ark_address"
-just bark send-to "$simulator_ark_address" "100000 sats"
+just bark send --wait "$simulator_ark_address" "100000 sats"
 
 bark_ark_address="$(just bark address 2>&1 | sed -n '/^tark1/p' | tail -n 1)"
 if [[ ! "$bark_ark_address" =~ ^tark1 ]]; then

--- a/scripts/test-send-regtest.sh
+++ b/scripts/test-send-regtest.sh
@@ -37,8 +37,13 @@ if [[ ! "$bark_ark_address" =~ ^tark1 ]]; then
   exit 1
 fi
 
-printf 'Sending 5000 sats from the simulator to Bark address %s.\n' "$bark_ark_address"
 printf '%s' "$bark_ark_address" | xcrun simctl pbcopy "$simulator_id"
+printf 'Verifying an abandoned recipient is not reused for a new amount.\n'
+"$maestro_command" test --udid "$simulator_id" \
+  --debug-output "$maestro_debug_output/recipient-reset-on-back" \
+  client/.maestro/subflows/send-recipient-reset-on-back.yml
+
+printf 'Sending 5000 sats from the simulator to Bark address %s.\n' "$bark_ark_address"
 "$maestro_command" test --udid "$simulator_id" \
   --debug-output "$maestro_debug_output/payment" \
   client/.maestro/subflows/send-funded-ark.yml


### PR DESCRIPTION
## Summary

- rebuild Send as a staged, Cash App-inspired flow with Noah's existing visual language
- support amount-first, recipient-first, fixed-request, and source-first MAX entry paths
- make Ark, Lightning, on-chain rail choice and Ark/on-chain funding choice explicit when needed
- add fee-aware read-only review, non-dismissible sending, retryable failure, and concise receipt success sheets
- preserve BIP-321 routing, Lightning address notes, transaction-history Pay Again, and draft state
- add focused unit coverage and a funded Ark regtest Maestro harness
- document reliable Expo dev-menu dismissal in a repo-local Maestro skill

## Verification

- `cd client && bun run check` (82 unit tests, lint, TypeScript)
- Noah-Regtest iOS simulator build via `xcodebuild`
- `SIMULATOR_ID=72314C64-A40A-4653-9165-61308DBF3474 scripts/test-send-regtest.sh`
  - cleared simulator state and completed fresh-wallet onboarding
  - copied a simulator Ark address and funded it with 100,000 sats from Bark
  - sent 5,000 sats from Noah to a real Bark Ark address
  - verified review, success, receipt, Done/reset, and Bark receipt/balance
- repeated the funded Ark Maestro flow after the fee-query guard change
  - verified the review reached `Estimated fee` before Confirm
  - completed the real payment, receipt, and reset flow
- both new Maestro flows pass `maestro check-syntax`
- `bash -n scripts/test-send-regtest.sh`
- final Standards and Spec review passes report no findings
