### PR TITLE
Add emergency exit fee previews and onchain deposits; fix keyboard clipping

### DIFF
--- a/client/src/components/ExitDepositBottomSheet.tsx
+++ b/client/src/components/ExitDepositBottomSheet.tsx
@@ -40,30 +40,32 @@ export function ExitDepositBottomSheet({
   });
   const address = addressQuery.data;
   const copied = !!address && isCopied(address);
+  const displayAddress =
+    address && address.length > 42 ? `${address.slice(0, 18)}…${address.slice(-12)}` : address;
 
   return (
     <AppBottomSheet isOpen={isOpen} onClose={onClose} detents={[0, "content"]}>
-      <View className="gap-5">
+      <View className="gap-6 px-2 pb-2">
         <View className="flex-row items-center justify-between gap-3">
-          <Text accessibilityRole="header" className="flex-1 text-2xl font-bold text-foreground">
+          <Text accessibilityRole="header" className="flex-1 text-xl font-semibold text-foreground">
             Deposit Onchain Funds
           </Text>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Close deposit details"
             onPress={onClose}
-            className="h-11 w-11 items-center justify-center rounded-full border border-border"
+            className="h-11 w-11 items-center justify-center rounded-full bg-muted/60"
           >
-            <Icon name="close" size={22} color={colors.foreground} />
+            <Icon name="close" size={20} color={colors.mutedForeground} />
           </Pressable>
         </View>
-        <View className="items-center gap-1">
+        <View className="items-center gap-2">
           <Text className="text-sm text-muted-foreground">Suggested deposit</Text>
-          <Text className="text-2xl font-semibold text-foreground">
+          <Text className="text-4xl font-semibold tracking-tight text-foreground">
             {formatAmount(broadcastFeeSat)}
           </Text>
-          <Text className="text-center text-sm text-muted-foreground">
-            Based on estimated broadcast fees. The amount needed may vary.
+          <Text className="text-center text-xs text-muted-foreground">
+            Estimated broadcast fees · amount may vary
           </Text>
         </View>
         {address ? (
@@ -71,45 +73,49 @@ export function ExitDepositBottomSheet({
             <View
               accessible
               accessibilityLabel="Bitcoin deposit address QR code"
-              className="self-center rounded-2xl bg-white p-4"
+              className="self-center rounded-[24px] bg-white p-5"
             >
               <QRCode value={address} size={Math.min(width - 96, 220)} />
             </View>
-            <View className="flex-row items-center gap-3">
-              <Text
-                selectable
-                className="flex-1 text-sm text-foreground"
-                numberOfLines={1}
-                ellipsizeMode="middle"
-              >
-                {address}
-              </Text>
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={copied ? "Address copied" : "Copy Bitcoin address"}
-                className="h-11 min-w-11 items-center justify-center gap-1"
-                onPress={() =>
-                  void copyWithState(address, address, {
-                    onCopy: () =>
-                      AccessibilityInfo.announceForAccessibility("Bitcoin address copied"),
-                  })
-                }
-                testID="exit-deposit-copy-button"
-              >
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={copied ? "Address copied" : "Copy Bitcoin address"}
+              accessibilityHint="Copies the full Bitcoin address"
+              className="flex-row items-center gap-4 rounded-2xl bg-card px-4 py-3"
+              style={({ pressed }) => ({ opacity: pressed ? 0.7 : 1 })}
+              onPress={() =>
+                void copyWithState(address, address, {
+                  onCopy: () =>
+                    AccessibilityInfo.announceForAccessibility("Bitcoin address copied"),
+                })
+              }
+              testID="exit-deposit-copy-button"
+            >
+              <View className="min-w-0 flex-1 gap-1">
+                <Text className="text-xs text-muted-foreground">Bitcoin address</Text>
+                <Text
+                  className="text-sm font-medium text-foreground"
+                  numberOfLines={1}
+                  ellipsizeMode="middle"
+                >
+                  {displayAddress}
+                </Text>
+              </View>
+              <View className="flex-row items-center gap-2">
                 <Icon
                   name={copied ? "checkmark-circle" : "copy-outline"}
-                  size={21}
+                  size={20}
                   color={copied ? COLORS.SUCCESS : COLORS.BITCOIN_ORANGE}
                 />
                 <Text
                   accessibilityLiveRegion="polite"
-                  className="text-[11px] font-semibold"
+                  className="text-sm font-semibold"
                   style={{ color: copied ? COLORS.SUCCESS : COLORS.BITCOIN_ORANGE }}
                 >
                   {copied ? "Copied" : "Copy"}
                 </Text>
-              </Pressable>
-            </View>
+              </View>
+            </Pressable>
           </>
         ) : addressQuery.isError ? (
           <View className="gap-3">
@@ -128,8 +134,8 @@ export function ExitDepositBottomSheet({
             <Text className="text-sm text-muted-foreground">Generating Bitcoin address…</Text>
           </View>
         )}
-        <Text className="text-center text-sm text-muted-foreground">
-          Wait for the deposit to confirm before progressing your exit.
+        <Text className="px-4 text-center text-xs leading-5 text-muted-foreground">
+          Wait for confirmation before progressing your exit.
         </Text>
       </View>
     </AppBottomSheet>

--- a/client/src/components/ExitDepositBottomSheet.tsx
+++ b/client/src/components/ExitDepositBottomSheet.tsx
@@ -3,7 +3,6 @@ import { useQuery } from "@tanstack/react-query";
 import { AccessibilityInfo, Pressable, useWindowDimensions, View } from "react-native";
 import QRCode from "react-native-qrcode-svg";
 import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
-import { NativeNoahIconButton } from "~/components/ui/NativeNoahIconButton";
 import { NativeNoahSecondaryButton } from "~/components/ui/NativeNoahSecondaryButton";
 import { NoahActivityIndicator } from "~/components/ui/NoahActivityIndicator";
 import { Text } from "~/components/ui/text";
@@ -11,6 +10,7 @@ import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
 import { useThemeColors } from "~/hooks/useTheme";
 import { useCopyToClipboard } from "~/lib/clipboardUtils";
 import { onchainAddress } from "~/lib/paymentsApi";
+import { COLORS } from "~/lib/styleConstants";
 
 export function ExitDepositBottomSheet({
   isOpen,
@@ -39,6 +39,7 @@ export function ExitDepositBottomSheet({
     retry: false,
   });
   const address = addressQuery.data;
+  const copied = !!address && isCopied(address);
 
   return (
     <AppBottomSheet isOpen={isOpen} onClose={onClose} detents={[0, "content"]}>
@@ -75,12 +76,18 @@ export function ExitDepositBottomSheet({
               <QRCode value={address} size={Math.min(width - 96, 220)} />
             </View>
             <View className="flex-row items-center gap-3">
-              <Text selectable className="flex-1 text-sm text-foreground">
+              <Text
+                selectable
+                className="flex-1 text-sm text-foreground"
+                numberOfLines={1}
+                ellipsizeMode="middle"
+              >
                 {address}
               </Text>
-              <NativeNoahIconButton
-                icon="copy"
-                accessibilityLabel={isCopied(address) ? "Address copied" : "Copy Bitcoin address"}
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={copied ? "Address copied" : "Copy Bitcoin address"}
+                className="h-11 min-w-11 items-center justify-center gap-1"
                 onPress={() =>
                   void copyWithState(address, address, {
                     onCopy: () =>
@@ -88,7 +95,20 @@ export function ExitDepositBottomSheet({
                   })
                 }
                 testID="exit-deposit-copy-button"
-              />
+              >
+                <Icon
+                  name={copied ? "checkmark-circle" : "copy-outline"}
+                  size={21}
+                  color={copied ? COLORS.SUCCESS : COLORS.BITCOIN_ORANGE}
+                />
+                <Text
+                  accessibilityLiveRegion="polite"
+                  className="text-[11px] font-semibold"
+                  style={{ color: copied ? COLORS.SUCCESS : COLORS.BITCOIN_ORANGE }}
+                >
+                  {copied ? "Copied" : "Copy"}
+                </Text>
+              </Pressable>
             </View>
           </>
         ) : addressQuery.isError ? (

--- a/client/src/components/ExitDepositBottomSheet.tsx
+++ b/client/src/components/ExitDepositBottomSheet.tsx
@@ -1,0 +1,117 @@
+import Icon from "@react-native-vector-icons/ionicons";
+import { useQuery } from "@tanstack/react-query";
+import { AccessibilityInfo, Pressable, useWindowDimensions, View } from "react-native";
+import QRCode from "react-native-qrcode-svg";
+import { AppBottomSheet } from "~/components/ui/AppBottomSheet";
+import { NativeNoahIconButton } from "~/components/ui/NativeNoahIconButton";
+import { NativeNoahSecondaryButton } from "~/components/ui/NativeNoahSecondaryButton";
+import { NoahActivityIndicator } from "~/components/ui/NoahActivityIndicator";
+import { Text } from "~/components/ui/text";
+import { useBitcoinAmountFormatter } from "~/hooks/useBitcoinAmountFormatter";
+import { useThemeColors } from "~/hooks/useTheme";
+import { useCopyToClipboard } from "~/lib/clipboardUtils";
+import { onchainAddress } from "~/lib/paymentsApi";
+
+export function ExitDepositBottomSheet({
+  isOpen,
+  onClose,
+  walletId,
+  broadcastFeeSat,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  walletId: string | null;
+  broadcastFeeSat: number;
+}) {
+  const colors = useThemeColors();
+  const formatAmount = useBitcoinAmountFormatter();
+  const { width } = useWindowDimensions();
+  const { copyWithState, isCopied } = useCopyToClipboard();
+  const addressQuery = useQuery({
+    queryKey: ["exit-deposit-address", walletId],
+    queryFn: async () => {
+      const result = await onchainAddress();
+      if (result.isErr()) throw result.error;
+      return result.value;
+    },
+    enabled: isOpen,
+    staleTime: Infinity,
+    retry: false,
+  });
+  const address = addressQuery.data;
+
+  return (
+    <AppBottomSheet isOpen={isOpen} onClose={onClose} detents={[0, "content"]}>
+      <View className="gap-5">
+        <View className="flex-row items-center justify-between gap-3">
+          <Text accessibilityRole="header" className="flex-1 text-2xl font-bold text-foreground">
+            Deposit Onchain Funds
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Close deposit details"
+            onPress={onClose}
+            className="h-11 w-11 items-center justify-center rounded-full border border-border"
+          >
+            <Icon name="close" size={22} color={colors.foreground} />
+          </Pressable>
+        </View>
+        <View className="items-center gap-1">
+          <Text className="text-sm text-muted-foreground">Suggested deposit</Text>
+          <Text className="text-2xl font-semibold text-foreground">
+            {formatAmount(broadcastFeeSat)}
+          </Text>
+          <Text className="text-center text-sm text-muted-foreground">
+            Based on estimated broadcast fees. The amount needed may vary.
+          </Text>
+        </View>
+        {address ? (
+          <>
+            <View
+              accessible
+              accessibilityLabel="Bitcoin deposit address QR code"
+              className="self-center rounded-2xl bg-white p-4"
+            >
+              <QRCode value={address} size={Math.min(width - 96, 220)} />
+            </View>
+            <View className="flex-row items-center gap-3">
+              <Text selectable className="flex-1 text-sm text-foreground">
+                {address}
+              </Text>
+              <NativeNoahIconButton
+                icon="copy"
+                accessibilityLabel={isCopied(address) ? "Address copied" : "Copy Bitcoin address"}
+                onPress={() =>
+                  void copyWithState(address, address, {
+                    onCopy: () =>
+                      AccessibilityInfo.announceForAccessibility("Bitcoin address copied"),
+                  })
+                }
+                testID="exit-deposit-copy-button"
+              />
+            </View>
+          </>
+        ) : addressQuery.isError ? (
+          <View className="gap-3">
+            <Text className="text-center text-sm text-muted-foreground">
+              Couldn’t generate a Bitcoin address.
+            </Text>
+            <NativeNoahSecondaryButton
+              label="Retry"
+              onPress={() => void addressQuery.refetch()}
+              fullWidth
+            />
+          </View>
+        ) : (
+          <View className="items-center gap-3 py-8">
+            <NoahActivityIndicator />
+            <Text className="text-sm text-muted-foreground">Generating Bitcoin address…</Text>
+          </View>
+        )}
+        <Text className="text-center text-sm text-muted-foreground">
+          Wait for the deposit to confirm before progressing your exit.
+        </Text>
+      </View>
+    </AppBottomSheet>
+  );
+}

--- a/client/src/components/ui/NativeNoahButton.tsx
+++ b/client/src/components/ui/NativeNoahButton.tsx
@@ -122,7 +122,12 @@ export function NativeNoahButton({
         style,
       ]}
     >
-      <Host seedColor={activeColor} style={hostStyle}>
+      {/* The screen handles keyboard avoidance; SwiftUI must not shift this fixed-height content. */}
+      <Host
+        seedColor={activeColor}
+        style={hostStyle}
+        ignoreSafeArea={Platform.OS === "ios" ? "keyboard" : undefined}
+      >
         {Platform.OS === "android" ? (
           <AndroidButton
             label={displayedLabel}

--- a/client/src/hooks/useUnilateralExit.ts
+++ b/client/src/hooks/useUnilateralExit.ts
@@ -1,4 +1,7 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { AppState } from "react-native";
+import { useIsFocused } from "@react-navigation/native";
 import { queryClient } from "~/queryClient";
 import { useAlert } from "~/contexts/AlertProvider";
 import { useWalletStore } from "~/store/walletStore";
@@ -7,13 +10,13 @@ import {
   allClaimableAtHeight,
   cancelExit,
   claimExits,
+  estimateEmergencyExitFee,
   getExitStatus,
   getExitVtxos,
   hasPendingExits,
   listClaimable,
   pendingExitTotal,
   progressExits,
-  startExitForEntireWallet,
   startExitForVtxos,
   syncExit,
   type ExitClaimResult,
@@ -27,6 +30,13 @@ import type {
   ExitVtxoResult,
 } from "react-native-nitro-ark";
 import logger from "~/lib/log";
+import {
+  exitEstimateKey,
+  isExitReviewCurrent,
+  EXIT_ESTIMATE_MAX_AGE_MS,
+  type ExitEstimateInputs,
+  type ExitFeeReview,
+} from "~/lib/exitFeeEstimate";
 
 const log = logger("useUnilateralExit");
 
@@ -55,6 +65,7 @@ const invalidateExitQueries = async () => {
     queryClient.invalidateQueries({ queryKey: ["balance"] }),
     queryClient.invalidateQueries({ queryKey: ["vtxos"] }),
     queryClient.invalidateQueries({ queryKey: ["getBlockHeight"] }),
+    queryClient.invalidateQueries({ queryKey: ["exit-fee-estimate"] }),
   ]);
 };
 
@@ -66,13 +77,13 @@ const readResult = <T>(result: Result<T, Error>): T => {
 };
 
 export function useExitOverview() {
-  const { isInitialized } = useWalletStore();
+  const { isInitialized, staticVtxoPubkey } = useWalletStore();
 
   return useQuery({
-    queryKey: ["exit-overview"],
+    queryKey: ["exit-overview", staticVtxoPubkey],
     queryFn: async (): Promise<ExitOverview> => {
       log.d("Loading exit overview");
-      readResult(await syncExit());
+      // Bark 0.7 syncExit permits progression. Reading this screen must not broadcast.
 
       const [
         exitsResult,
@@ -145,26 +156,83 @@ export function useExitOverview() {
   });
 }
 
-export function useStartWalletExit() {
-  const { showAlert } = useAlert();
-
-  return useMutation<void, Error>({
-    mutationFn: async () => {
-      log.i("User requested wallet exit start");
-      readResult(await startExitForEntireWallet());
-    },
-    onSuccess: async () => {
-      await invalidateExitQueries();
-      showAlert({
-        title: "Exit Started",
-        description: "Your wallet exits have been registered. Progress them until claimable.",
-      });
-    },
-    onError: (error) => {
-      log.e("Wallet exit start mutation failed", [error]);
-      showAlert({ title: "Failed to Start Exit", description: error.message });
-    },
+export function useExitFeeEstimate(inputs: ExitEstimateInputs, enabled: boolean) {
+  const isFocused = useIsFocused();
+  const [isForeground, setIsForeground] = useState(AppState.currentState === "active");
+  const [foregroundRevision, setForegroundRevision] = useState(0);
+  const [settledKey, setSettledKey] = useState("");
+  const [isReviewing, setIsReviewing] = useState(false);
+  const contextKey = exitEstimateKey({
+    ...inputs,
+    revision: `${inputs.revision}:${isFocused}:${isForeground}:${foregroundRevision}`,
   });
+  const canEstimate = enabled && isFocused && isForeground && inputs.vtxoIds.length > 0;
+  const currentContext = useRef({ contextKey, canEstimate });
+  useLayoutEffect(() => {
+    currentContext.current = { contextKey, canEstimate };
+  }, [contextKey, canEstimate]);
+
+  useEffect(() => {
+    if (isFocused) setForegroundRevision((revision) => revision + 1);
+  }, [isFocused]);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (state) => {
+      setIsForeground(state === "active");
+      if (state === "active") setForegroundRevision((revision) => revision + 1);
+    });
+    return () => subscription.remove();
+  }, []);
+
+  useEffect(() => {
+    if (!canEstimate) return;
+    const timer = setTimeout(() => setSettledKey(contextKey), 350);
+    return () => clearTimeout(timer);
+  }, [contextKey, canEstimate]);
+
+  const query = useQuery({
+    // Switch keys immediately, before debounce: never expose the previous selection's quote.
+    queryKey: ["exit-fee-estimate", contextKey],
+    queryFn: async () =>
+      readResult(await estimateEmergencyExitFee(inputs.vtxoIds, inputs.destinationAddress)),
+    enabled: canEstimate && settledKey === contextKey,
+    retry: false,
+    staleTime: EXIT_ESTIMATE_MAX_AGE_MS,
+    refetchInterval: EXIT_ESTIMATE_MAX_AGE_MS,
+  });
+
+  const review = async (): Promise<ExitFeeReview | undefined> => {
+    if (!canEstimate || isReviewing) return;
+    setIsReviewing(true);
+    // Always refresh before review; the snapshot also pins the eventual action inputs.
+    const result = await estimateEmergencyExitFee(
+      inputs.vtxoIds,
+      inputs.destinationAddress,
+    ).finally(() => setIsReviewing(false));
+    return {
+      inputs: { ...inputs, vtxoIds: [...inputs.vtxoIds] },
+      contextKey,
+      estimate: result.isOk() ? result.value : undefined,
+      reviewedAt: Date.now(),
+    };
+  };
+
+  return {
+    contextKey,
+    estimate: canEstimate && settledKey === contextKey && !query.isError ? query.data : undefined,
+    isLoading: canEstimate && (settledKey !== contextKey || query.isPending),
+    isError: canEstimate && settledKey === contextKey && query.isError,
+    retry: () => query.refetch(),
+    review,
+    isReviewing,
+    isCurrentReview: (snapshot: ExitFeeReview) =>
+      currentContext.current.canEstimate &&
+      isExitReviewCurrent(snapshot, currentContext.current.contextKey) &&
+      useWalletStore.getState().staticVtxoPubkey === snapshot.inputs.walletId &&
+      useWalletStore.getState().isWalletLoaded &&
+      !useWalletStore.getState().isWalletSuspended &&
+      !useWalletStore.getState().isBackgroundJobRunning,
+  };
 }
 
 export function useStartVtxoExit() {
@@ -173,6 +241,14 @@ export function useStartVtxoExit() {
   return useMutation<void, Error, string[]>({
     mutationFn: async (vtxoIds) => {
       log.i("User requested selected VTXO exit start", [{ vtxo_ids: vtxoIds }]);
+      const available = new Set(
+        readResult(await getVtxos())
+          .filter((vtxo) => vtxo.state === "Spendable")
+          .map((vtxo) => vtxo.id),
+      );
+      if (vtxoIds.some((id) => !available.has(id))) {
+        throw new Error("Available VTXOs changed. Refresh and review the exit again.");
+      }
       readResult(await startExitForVtxos(vtxoIds));
     },
     onSuccess: async () => {

--- a/client/src/hooks/useUnilateralExit.ts
+++ b/client/src/hooks/useUnilateralExit.ts
@@ -77,11 +77,29 @@ const readResult = <T>(result: Result<T, Error>): T => {
 };
 
 export function useExitOverview() {
-  const { isInitialized, staticVtxoPubkey } = useWalletStore();
+  const {
+    isInitialized,
+    isWalletLoaded,
+    isWalletSuspended,
+    isBackgroundJobRunning,
+    staticVtxoPubkey,
+  } = useWalletStore();
+  const walletReady =
+    isInitialized && isWalletLoaded && !isWalletSuspended && !isBackgroundJobRunning;
 
   return useQuery({
     queryKey: ["exit-overview", staticVtxoPubkey],
     queryFn: async (): Promise<ExitOverview> => {
+      // Explicit refetch bypasses enabled and may come from a stale render.
+      const wallet = useWalletStore.getState();
+      if (
+        !wallet.isInitialized ||
+        !wallet.isWalletLoaded ||
+        wallet.isWalletSuspended ||
+        wallet.isBackgroundJobRunning
+      ) {
+        throw new Error("Wait for the wallet to be ready before refreshing exits.");
+      }
       log.d("Loading exit overview");
       // Bark 0.7 syncExit permits progression. Reading this screen must not broadcast.
 
@@ -150,7 +168,7 @@ export function useExitOverview() {
 
       return overview;
     },
-    enabled: isInitialized,
+    enabled: walletReady,
     retry: false,
     refetchInterval: (query) => (query.state.data?.hasPending ? 60_000 : false),
   });

--- a/client/src/lib/exitApi.ts
+++ b/client/src/lib/exitApi.ts
@@ -3,12 +3,24 @@ import { err, ok, Result, ResultAsync } from "neverthrow";
 import logger from "~/lib/log";
 import type {
   ExitProgressStatusResult,
+  ExitFeeEstimate,
   ExitStateDetails,
   ExitStatusResult,
   ExitVtxoResult,
 } from "react-native-nitro-ark";
 
 const log = logger("exitApi");
+
+export const estimateEmergencyExitFee = async (
+  vtxoIds: string[],
+  destinationAddress?: string,
+): Promise<Result<ExitFeeEstimate, Error>> => {
+  // Do not sync here: Bark's sync can progress initialized exits.
+  return ResultAsync.fromPromise(
+    NitroArk.estimateEmergencyExitFee(vtxoIds, undefined, destinationAddress),
+    (error) => (error instanceof Error ? error : new Error(String(error))),
+  );
+};
 
 export type ExitClaimResult = {
   txid: string;
@@ -57,21 +69,6 @@ const summarizeProgress = (progress: ExitProgressStatusResult) => ({
   state_details: summarizeStateDetails(progress.state_details),
   error: progress.error,
 });
-
-export const startExitForEntireWallet = async (): Promise<Result<void, Error>> => {
-  log.i("Starting exit for entire wallet");
-  const result = await ResultAsync.fromPromise(
-    NitroArk.startExitForEntireWallet(),
-    (e) => e as Error,
-  );
-
-  if (result.isErr()) {
-    log.e("Failed to start exit for entire wallet", [result.error]);
-  } else {
-    log.i("Started exit for entire wallet");
-  }
-  return result;
-};
 
 export const startExitForVtxos = async (vtxoIds: string[]): Promise<Result<void, Error>> => {
   log.i("Starting exit for selected VTXOs", [{ vtxo_ids: vtxoIds }]);

--- a/client/src/lib/exitFeeEstimate.ts
+++ b/client/src/lib/exitFeeEstimate.ts
@@ -1,0 +1,46 @@
+import type { ExitFeeEstimate } from "react-native-nitro-ark";
+
+export const EXIT_ESTIMATE_MAX_AGE_MS = 30_000;
+
+export type ExitEstimateInputs = {
+  walletId: string | null;
+  vtxoIds: string[];
+  amountSat: number;
+  scope: "wallet" | "selected" | "claim";
+  destinationAddress?: string;
+  revision: string;
+};
+
+export type ExitFeeReview = {
+  inputs: ExitEstimateInputs;
+  contextKey: string;
+  estimate?: ExitFeeEstimate;
+  reviewedAt: number;
+};
+
+export function exitEstimateKey(inputs: ExitEstimateInputs): string {
+  return JSON.stringify({ ...inputs, vtxoIds: [...inputs.vtxoIds].sort() });
+}
+
+export function isExitReviewCurrent(
+  review: ExitFeeReview,
+  contextKey: string,
+  now = Date.now(),
+): boolean {
+  return review.contextKey === contextKey && now - review.reviewedAt < EXIT_ESTIMATE_MAX_AGE_MS;
+}
+
+export function exitReceiveAmount(amountSat: number, claimFeeSat: number): number {
+  // Broadcast fees are funded separately by confirmed onchain UTXOs.
+  return Math.max(0, amountSat - claimFeeSat);
+}
+
+export function exitFeeWarning(amountSat: number, estimate: ExitFeeEstimate, claimOnly = false) {
+  if (estimate.claim_fee_sat >= amountSat) {
+    return "The estimated claim fee consumes the entire recovered value. A claim may not be possible.";
+  }
+  if (!claimOnly && estimate.total_fee_sat >= amountSat) {
+    return "Estimated total fees meet or exceed the value being recovered.";
+  }
+  return undefined;
+}

--- a/client/src/screens/UnilateralExitScreen.tsx
+++ b/client/src/screens/UnilateralExitScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Keyboard,
   KeyboardAvoidingView,
@@ -8,7 +8,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from "react-native";
-import { useNavigation, useRoute, type RouteProp } from "@react-navigation/native";
+import { useIsFocused, useNavigation, useRoute, type RouteProp } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import Icon from "@react-native-vector-icons/ionicons";
 import { AlertTriangle } from "lucide-react-native";
@@ -23,15 +23,19 @@ import { NativeNoahSecondaryButton } from "~/components/ui/NativeNoahSecondaryBu
 import { NoahActivityIndicator } from "~/components/ui/NoahActivityIndicator";
 import { NoahSafeAreaView } from "~/components/NoahSafeAreaView";
 import { ConfirmationDialog } from "~/components/ConfirmationDialog";
+import { ExitDepositBottomSheet } from "~/components/ExitDepositBottomSheet";
 import {
   useCancelExit,
   useClaimExits,
   useExitOverview,
+  useExitFeeEstimate,
   useProgressExits,
   useStartVtxoExit,
-  useStartWalletExit,
-  useSyncExits,
 } from "~/hooks/useUnilateralExit";
+import { useBalance } from "~/hooks/useWallet";
+import { useWalletStore } from "~/store/walletStore";
+import { useAlert } from "~/contexts/AlertProvider";
+import { exitReceiveAmount, exitFeeWarning, type ExitFeeReview } from "~/lib/exitFeeEstimate";
 import { APP_VARIANT } from "~/config";
 import { getMempoolTxUrl } from "~/constants";
 import {
@@ -443,6 +447,151 @@ const ExitModePicker = ({
   />
 );
 
+type ExitQuote = ReturnType<typeof useExitFeeEstimate>;
+
+function exitReviewDescription(review: ExitFeeReview, formatAmount: (amount: number) => string) {
+  const { inputs, estimate } = review;
+  const claimOnly = inputs.scope === "claim";
+  const scope =
+    inputs.scope === "wallet"
+      ? "Entire wallet (available VTXOs)"
+      : claimOnly
+        ? "Claimable exits"
+        : "Selected VTXOs";
+  const count = inputs.vtxoIds.length;
+  const lines = [
+    `${scope}: ${count} ${count === 1 ? "VTXO" : "VTXOs"} · ${formatAmount(inputs.amountSat)}`,
+  ];
+  if (inputs.destinationAddress) lines.push(`Destination: ${inputs.destinationAddress}`);
+  if (estimate) {
+    if (!claimOnly) {
+      lines.push(`Estimated total fees: ${formatAmount(estimate.total_fee_sat)}`);
+      lines.push(
+        `Broadcast: ${formatAmount(estimate.exit_broadcast_fee_sat)} (paid separately from confirmed onchain funds)`,
+      );
+    }
+    lines.push(
+      `Claim fee: ${formatAmount(estimate.claim_fee_sat)} (deducted from recovered funds)`,
+    );
+    lines.push(
+      `Estimated amount to receive: ${formatAmount(exitReceiveAmount(inputs.amountSat, estimate.claim_fee_sat))}`,
+    );
+    if (!claimOnly) {
+      lines.push(
+        estimate.fundable
+          ? "Broadcast funding: sufficient confirmed onchain funds at this estimate."
+          : "Additional confirmed onchain funds required. You are starting tracking anyway; fund the wallet before progressing.",
+      );
+    }
+    const warning = exitFeeWarning(inputs.amountSat, estimate, claimOnly);
+    if (warning) lines.push(warning);
+  } else {
+    lines.push(
+      "Fee estimate unavailable. Fees and amount to receive are unknown. Continue without an estimate only if you accept this uncertainty.",
+    );
+    if (!claimOnly)
+      lines.push("Broadcast funding status is unknown; confirmed onchain funds are required.");
+  }
+  lines.push(
+    claimOnly
+      ? "This broadcasts the claim transaction. Earlier broadcast fees are not deducted again. Fees may change."
+      : "This starts tracking. Use Progress to broadcast exit transactions. Fees may change; the claim estimate updates when you enter a destination.",
+  );
+  return lines.join("\n\n");
+}
+
+const ExitFeePreview = ({
+  quote,
+  amountSat,
+  claimOnly = false,
+}: {
+  quote: ExitQuote;
+  amountSat: number;
+  claimOnly?: boolean;
+}) => {
+  const formatAmount = useBitcoinAmountFormatter();
+  const estimate = quote.estimate;
+  if (quote.isLoading) {
+    return (
+      <View className="mt-4 flex-row items-center gap-3">
+        <NoahActivityIndicator />
+        <Text className="text-sm text-muted-foreground">Estimating fees…</Text>
+      </View>
+    );
+  }
+  if (quote.isError) {
+    return (
+      <View className="mt-4 gap-2">
+        <Text className="font-semibold text-foreground">Fee estimate unavailable</Text>
+        <Text className="text-sm text-muted-foreground">
+          Fees and amount to receive are unknown. You can retry or continue without an estimate.
+        </Text>
+        <NativeNoahSecondaryButton
+          label="Retry estimate"
+          onPress={() => void quote.retry()}
+          fullWidth
+        />
+      </View>
+    );
+  }
+  if (!estimate) return null;
+  const warning = exitFeeWarning(amountSat, estimate, claimOnly);
+  return (
+    <View className="mt-4 gap-3 rounded-lg border border-border bg-background p-3">
+      <View>
+        <Text className="text-sm text-muted-foreground">
+          {claimOnly ? "Estimated claim fee" : "Estimated total fees"}
+        </Text>
+        <Text className="mt-1 text-xl font-semibold text-foreground">
+          {formatAmount(claimOnly ? estimate.claim_fee_sat : estimate.total_fee_sat)}
+        </Text>
+      </View>
+      {!claimOnly ? (
+        <>
+          <ExitFeeRow label="Broadcast fees" amount={estimate.exit_broadcast_fee_sat} />
+          <Text className="text-xs leading-4 text-muted-foreground">
+            Paid separately from confirmed onchain funds.
+          </Text>
+          <ExitFeeRow label="Claim fee" amount={estimate.claim_fee_sat} />
+        </>
+      ) : null}
+      <Text className="text-xs leading-4 text-muted-foreground">
+        Claim fee is deducted from recovered funds.
+        {claimOnly ? " Earlier broadcast fees are not deducted again." : ""}
+      </Text>
+      <ExitFeeRow
+        label="Estimated amount to receive"
+        amount={exitReceiveAmount(amountSat, estimate.claim_fee_sat)}
+      />
+      {warning ? (
+        <Text accessibilityRole="alert" className="font-semibold text-destructive">
+          {warning}
+        </Text>
+      ) : null}
+      {!claimOnly && !estimate.fundable ? (
+        <Text className="text-sm font-semibold text-amber-700 dark:text-amber-300">
+          Additional confirmed onchain funds required. Deposit funds and wait for confirmation
+          before progressing.
+        </Text>
+      ) : null}
+      <Text className="text-xs leading-4 text-muted-foreground">
+        Fees may change.
+        {!claimOnly ? " Claim fee updates when you enter a destination at the claim stage." : ""}
+      </Text>
+    </View>
+  );
+};
+
+const ExitFeeRow = ({ label, amount }: { label: string; amount: number }) => {
+  const formatAmount = useBitcoinAmountFormatter();
+  return (
+    <View className="flex-row justify-between gap-3">
+      <Text className="flex-1 text-sm text-muted-foreground">{label}</Text>
+      <Text className="text-sm font-semibold text-foreground">{formatAmount(amount)}</Text>
+    </View>
+  );
+};
+
 const StartExitPanel = ({
   title = "Start Emergency Exit",
   description = "Choose whether to exit all available VTXOs or only specific ones.",
@@ -458,6 +607,8 @@ const StartExitPanel = ({
   onClear,
   onStart,
   onCollapse,
+  quote,
+  onDeposit,
 }: {
   title?: string;
   description?: string;
@@ -473,11 +624,16 @@ const StartExitPanel = ({
   onClear: () => void;
   onStart: () => void;
   onCollapse?: () => void;
+  quote: ExitQuote;
+  onDeposit: () => void;
 }) => {
   const formatBitcoinAmount = useBitcoinAmountFormatter();
   const hasSelection = selectedCount > 0;
   const startDisabled =
-    isBusy || spendableVtxos.length === 0 || (mode === "selected" && !hasSelection);
+    isBusy ||
+    quote.isLoading ||
+    spendableVtxos.length === 0 ||
+    (mode === "selected" && !hasSelection);
 
   return (
     <View className="rounded-lg border border-border bg-card p-4">
@@ -551,15 +707,48 @@ const StartExitPanel = ({
         </View>
       )}
 
-      <NativeNoahButton
-        label={mode === "wallet" ? "Start Wallet Exit" : "Start Selected Exit"}
-        className="mt-4"
-        onPress={onStart}
-        disabled={startDisabled}
-        isLoading={isBusy}
-        loadingLabel="Starting..."
-        fullWidth
-      />
+      {mode === "selected" && !hasSelection ? (
+        <Text className="mt-4 text-sm text-muted-foreground">
+          Select VTXOs to estimate exit fees.
+        </Text>
+      ) : (
+        <ExitFeePreview
+          quote={quote}
+          amountSat={
+            mode === "wallet"
+              ? spendableVtxos.reduce((total, vtxo) => total + vtxo.amount, 0)
+              : selectedAmount
+          }
+        />
+      )}
+      {quote.estimate && !quote.estimate.fundable ? (
+        <>
+          <NativeNoahButton
+            label="Deposit Onchain Funds"
+            className="mt-4"
+            onPress={onDeposit}
+            disabled={isBusy}
+            fullWidth
+          />
+          <NativeNoahSecondaryButton
+            label={quote.isReviewing ? "Refreshing estimate..." : "Start tracking anyway"}
+            className="mt-3"
+            onPress={onStart}
+            disabled={startDisabled}
+            fullWidth
+          />
+        </>
+      ) : (
+        <NativeNoahButton
+          label={quote.isError ? "Continue without estimate" : "Review Exit"}
+          className="mt-4"
+          onPress={onStart}
+          disabled={startDisabled}
+          isLoading={isBusy}
+          loadingLabel={quote.isReviewing ? "Refreshing estimate..." : "Starting..."}
+          fullWidth
+        />
+      )}
     </View>
   );
 };
@@ -636,17 +825,25 @@ const UnilateralExitScreen = () => {
     () => new Set(routeSelectedVtxoIds ?? []),
   );
   const [isNewExitExpanded, setIsNewExitExpanded] = useState(!!routeSelectedVtxoIds?.length);
-  const [showStartConfirm, setShowStartConfirm] = useState(false);
+  const [deposit, setDeposit] = useState<{ walletId: string | null; broadcastFeeSat: number }>();
+  const [startReview, setStartReview] = useState<ExitFeeReview>();
   const [showProgressConfirm, setShowProgressConfirm] = useState(false);
-  const [showClaimConfirm, setShowClaimConfirm] = useState(false);
+  const [claimReview, setClaimReview] = useState<ExitFeeReview>();
   const [cancelExitVtxoId, setCancelExitVtxoId] = useState<string | null>(null);
 
   const overviewQuery = useExitOverview();
-  const startWalletExit = useStartWalletExit();
+  const { showAlert } = useAlert();
+  const { staticVtxoPubkey, isWalletLoaded, isWalletSuspended, isBackgroundJobRunning } =
+    useWalletStore();
+  const balanceQuery = useBalance();
+  const isFocused = useIsFocused();
+  const { refetch: refetchOverview } = overviewQuery;
+  useEffect(() => {
+    if (isFocused) void refetchOverview();
+  }, [isFocused, balanceQuery.dataUpdatedAt, refetchOverview]);
   const startVtxoExit = useStartVtxoExit();
   const cancelExit = useCancelExit();
   const progressExits = useProgressExits();
-  const syncExits = useSyncExits();
   const claimExits = useClaimExits();
 
   const overview = overviewQuery.data;
@@ -707,22 +904,43 @@ const UnilateralExitScreen = () => {
   const btcValidation = trimmedDestination ? validateBitcoinAddress(trimmedDestination) : null;
   const isValidDestination =
     !!btcValidation?.valid && isNetworkMatch(btcValidation.network, "onchain");
+  const startVtxos = exitStartMode === "wallet" ? spendableVtxos : selectedExitVtxos;
+  const startAmount = startVtxos.reduce((total, vtxo) => total + vtxo.amount, 0);
+  const walletReady = isWalletLoaded && !isWalletSuspended && !isBackgroundJobRunning;
+  const revision = `${overviewQuery.dataUpdatedAt}:${balanceQuery.dataUpdatedAt}:${walletReady}`;
+  const startQuote = useExitFeeEstimate(
+    {
+      walletId: staticVtxoPubkey,
+      vtxoIds: startVtxos.map((vtxo) => vtxo.id),
+      amountSat: startAmount,
+      scope: exitStartMode,
+      revision,
+    },
+    walletReady && (exits.length === 0 || isNewExitExpanded),
+  );
+  const claimQuote = useExitFeeEstimate(
+    {
+      walletId: staticVtxoPubkey,
+      vtxoIds: claimableIds,
+      amountSat: claimableTotal,
+      scope: "claim",
+      destinationAddress: trimmedDestination,
+      revision,
+    },
+    walletReady && isValidDestination,
+  );
+  useEffect(() => setStartReview(undefined), [startQuote.contextKey]);
+  useEffect(() => setClaimReview(undefined), [claimQuote.contextKey]);
   const isBusy =
-    startWalletExit.isPending ||
+    !walletReady ||
+    startQuote.isReviewing ||
+    claimQuote.isReviewing ||
     startVtxoExit.isPending ||
     progressExits.isPending ||
-    syncExits.isPending ||
     claimExits.isPending ||
     cancelExit.isPending;
   const canStartNewExit = spendableVtxos.length > 0;
 
-  const startLabel = exitStartMode === "selected" ? "Start Selected Exit" : "Start Wallet Exit";
-  const startDescription =
-    exitStartMode === "selected"
-      ? `This starts unilateral exit tracking for ${selectedExitVtxoIdList.length} selected ${
-          selectedExitVtxoIdList.length === 1 ? "VTXO" : "VTXOs"
-        }. Use this only if normal offboarding is unavailable.`
-      : "This starts unilateral exit tracking for all available funds. Use this only if normal offboarding is unavailable.";
   const allClaimableHeight = overview?.allClaimableAtHeight;
   const currentBlockHeight = overview?.blockHeight;
   const claimableBlockLabel =
@@ -735,16 +953,40 @@ const UnilateralExitScreen = () => {
         : "Unknown";
   const allClaimableRemainingLabel = formatBlocksRemaining(currentBlockHeight, allClaimableHeight);
 
+  const staleReview = () =>
+    showAlert({
+      title: "Review Exit Again",
+      description:
+        "The estimate expired or your wallet changed. Review the current details before continuing.",
+    });
+
   const handleStart = () => {
-    if (exitStartMode === "selected") {
-      if (selectedExitVtxoIdList.length === 0) {
-        return;
-      }
-      startVtxoExit.mutate(selectedExitVtxoIdList);
-    } else {
-      startWalletExit.mutate();
+    if (!startReview || !startQuote.isCurrentReview(startReview)) {
+      setStartReview(undefined);
+      staleReview();
+      return;
     }
-    setShowStartConfirm(false);
+    // Even wallet mode uses the reviewed IDs, so newly arriving funds are never added silently.
+    startVtxoExit.mutate(startReview.inputs.vtxoIds);
+    setStartReview(undefined);
+  };
+
+  const reviewStart = async () => {
+    const snapshot = await startQuote.review();
+    if (snapshot && startQuote.isCurrentReview(snapshot)) setStartReview(snapshot);
+  };
+
+  const reviewClaim = async () => {
+    const snapshot = await claimQuote.review();
+    if (snapshot && claimQuote.isCurrentReview(snapshot)) setClaimReview(snapshot);
+  };
+
+  const depositOnchain = () => {
+    if (!startQuote.estimate || !walletReady) return;
+    setDeposit({
+      walletId: staticVtxoPubkey,
+      broadcastFeeSat: startQuote.estimate.exit_broadcast_fee_sat,
+    });
   };
 
   const toggleExitVtxoSelection = (vtxoId: string) => {
@@ -776,15 +1018,20 @@ const UnilateralExitScreen = () => {
   };
 
   const handleClaim = () => {
-    if (!isValidDestination) {
+    if (
+      !claimReview ||
+      !claimQuote.isCurrentReview(claimReview) ||
+      !claimReview.inputs.destinationAddress
+    ) {
+      setClaimReview(undefined);
+      staleReview();
       return;
     }
-
     claimExits.mutate({
-      vtxoIds: claimableIds,
-      destinationAddress: trimmedDestination,
+      vtxoIds: claimReview.inputs.vtxoIds,
+      destinationAddress: claimReview.inputs.destinationAddress,
     });
-    setShowClaimConfirm(false);
+    setClaimReview(undefined);
   };
 
   const handleCancelExit = () => {
@@ -817,9 +1064,9 @@ const UnilateralExitScreen = () => {
               <NativeNoahIconButton
                 icon="refresh"
                 accessibilityLabel="Refresh emergency exits"
-                onPress={() => syncExits.mutate()}
+                onPress={() => void overviewQuery.refetch()}
                 disabled={isBusy}
-                isLoading={syncExits.isPending}
+                isLoading={overviewQuery.isFetching}
                 testID="emergency-exits-refresh-button"
               />
             </View>
@@ -858,7 +1105,9 @@ const UnilateralExitScreen = () => {
                     onToggleVtxo={toggleExitVtxoSelection}
                     onSelectAll={selectAllExitVtxos}
                     onClear={clearExitVtxoSelection}
-                    onStart={() => setShowStartConfirm(true)}
+                    onStart={reviewStart}
+                    quote={startQuote}
+                    onDeposit={depositOnchain}
                   />
                 ) : null}
               </EmptyExitState>
@@ -923,7 +1172,8 @@ const UnilateralExitScreen = () => {
                   {staleExitCount > 0 ? (
                     <Text className="mt-3 text-sm leading-5 text-muted-foreground">
                       {staleExitCount} {staleExitCount === 1 ? "exit is" : "exits are"} behind the
-                      current chain height. Sync status to refresh chain-derived state.
+                      current chain height. Use Progress to check the chain; this can also broadcast
+                      exit transactions.
                     </Text>
                   ) : null}
                 </View>
@@ -935,7 +1185,7 @@ const UnilateralExitScreen = () => {
                     </Text>
                     <Text className="mt-1 text-sm leading-5 text-amber-700/90 dark:text-amber-200/90">
                       No further claim action is available for VTXOs in Claiming. Wait for the claim
-                      transaction to confirm, then sync status to mark them claimed.
+                      transaction to confirm, then use Progress to update tracked state.
                     </Text>
                   </View>
                 ) : null}
@@ -978,13 +1228,13 @@ const UnilateralExitScreen = () => {
 
                 <View className="mb-5 flex-row gap-x-3">
                   <NativeNoahSecondaryButton
-                    label={syncExits.isPending ? "Syncing..." : "Sync Status"}
+                    label={overviewQuery.isFetching ? "Refreshing..." : "Refresh Status"}
                     className="flex-1"
-                    onPress={() => syncExits.mutate()}
+                    onPress={() => void overviewQuery.refetch()}
                     disabled={isBusy}
                     fullWidth
                   />
-                  {overview?.hasPending ? (
+                  {overview?.hasPending || claimable.length > 0 || claimInProgressCount > 0 ? (
                     <NativeNoahButton
                       label="Progress"
                       className="flex-1"
@@ -996,6 +1246,11 @@ const UnilateralExitScreen = () => {
                     />
                   ) : null}
                 </View>
+
+                <Text className="mb-5 text-sm leading-5 text-muted-foreground">
+                  Refresh Status reloads saved wallet state. Progress checks the chain and can
+                  broadcast or fee-bump exit transactions.
+                </Text>
 
                 {claimable.length > 0 ? (
                   <View className="mb-5 rounded-lg border border-border bg-card p-4">
@@ -1018,13 +1273,18 @@ const UnilateralExitScreen = () => {
                         Enter a valid {APP_VARIANT} on-chain address.
                       </Text>
                     ) : null}
+                    {isValidDestination ? (
+                      <ExitFeePreview quote={claimQuote} amountSat={claimableTotal} claimOnly />
+                    ) : null}
                     <NativeNoahButton
-                      label="Claim Claimable Exits"
+                      label={claimQuote.isError ? "Continue without estimate" : "Review Claim"}
                       className="mt-4"
-                      disabled={!isValidDestination || isBusy}
-                      isLoading={claimExits.isPending}
-                      loadingLabel="Claiming..."
-                      onPress={() => setShowClaimConfirm(true)}
+                      disabled={!isValidDestination || isBusy || claimQuote.isLoading}
+                      isLoading={claimExits.isPending || claimQuote.isReviewing}
+                      loadingLabel={
+                        claimQuote.isReviewing ? "Refreshing estimate..." : "Claiming..."
+                      }
+                      onPress={reviewClaim}
                       fullWidth
                     />
                   </View>
@@ -1046,7 +1306,9 @@ const UnilateralExitScreen = () => {
                         onToggleVtxo={toggleExitVtxoSelection}
                         onSelectAll={selectAllExitVtxos}
                         onClear={clearExitVtxoSelection}
-                        onStart={() => setShowStartConfirm(true)}
+                        onStart={reviewStart}
+                        quote={startQuote}
+                        onDeposit={depositOnchain}
                         onCollapse={() => setIsNewExitExpanded(false)}
                       />
                     ) : (
@@ -1062,12 +1324,19 @@ const UnilateralExitScreen = () => {
             )}
 
             <ConfirmationDialog
-              open={showStartConfirm}
-              onOpenChange={setShowStartConfirm}
-              title="Start Emergency Exit"
-              description={startDescription}
-              confirmText={startLabel}
+              open={!!startReview && startReview.contextKey === startQuote.contextKey}
+              onOpenChange={(open) => {
+                if (!open) setStartReview(undefined);
+              }}
+              title={startReview?.estimate ? "Start Emergency Exit" : "Continue without estimate?"}
+              description={
+                startReview ? exitReviewDescription(startReview, formatBitcoinAmount) : ""
+              }
+              confirmText={
+                startReview?.inputs.scope === "wallet" ? "Start Wallet Exit" : "Start Selected Exit"
+              }
               onConfirm={handleStart}
+              isConfirmDisabled={isBusy}
             />
             <ConfirmationDialog
               open={cancelExitVtxoId !== null}
@@ -1093,16 +1362,27 @@ const UnilateralExitScreen = () => {
               }}
             />
             <ConfirmationDialog
-              open={showClaimConfirm}
-              onOpenChange={setShowClaimConfirm}
-              title="Claim Exits"
-              description="This broadcasts the final claim transaction for all currently claimable exits."
-              confirmText="Broadcast Claim"
+              open={!!claimReview && claimReview.contextKey === claimQuote.contextKey}
+              onOpenChange={(open) => {
+                if (!open) setClaimReview(undefined);
+              }}
+              title={claimReview?.estimate ? "Claim Exits" : "Continue without estimate?"}
+              description={
+                claimReview ? exitReviewDescription(claimReview, formatBitcoinAmount) : ""
+              }
+              confirmText={claimReview?.estimate ? "Broadcast Claim" : "Broadcast without estimate"}
               onConfirm={handleClaim}
+              isConfirmDisabled={isBusy}
             />
           </ScrollView>
         </TouchableWithoutFeedback>
       </KeyboardAvoidingView>
+      <ExitDepositBottomSheet
+        isOpen={!!deposit && deposit.walletId === staticVtxoPubkey && walletReady && isFocused}
+        onClose={() => setDeposit(undefined)}
+        walletId={staticVtxoPubkey}
+        broadcastFeeSat={deposit?.broadcastFeeSat ?? 0}
+      />
     </NoahSafeAreaView>
   );
 };

--- a/client/src/screens/UnilateralExitScreen.tsx
+++ b/client/src/screens/UnilateralExitScreen.tsx
@@ -835,12 +835,13 @@ const UnilateralExitScreen = () => {
   const { showAlert } = useAlert();
   const { staticVtxoPubkey, isWalletLoaded, isWalletSuspended, isBackgroundJobRunning } =
     useWalletStore();
+  const walletReady = isWalletLoaded && !isWalletSuspended && !isBackgroundJobRunning;
   const balanceQuery = useBalance();
   const isFocused = useIsFocused();
   const { refetch: refetchOverview } = overviewQuery;
   useEffect(() => {
-    if (isFocused) void refetchOverview();
-  }, [isFocused, balanceQuery.dataUpdatedAt, refetchOverview]);
+    if (isFocused && walletReady) void refetchOverview();
+  }, [isFocused, walletReady, balanceQuery.dataUpdatedAt, refetchOverview]);
   const startVtxoExit = useStartVtxoExit();
   const cancelExit = useCancelExit();
   const progressExits = useProgressExits();
@@ -906,7 +907,6 @@ const UnilateralExitScreen = () => {
     !!btcValidation?.valid && isNetworkMatch(btcValidation.network, "onchain");
   const startVtxos = exitStartMode === "wallet" ? spendableVtxos : selectedExitVtxos;
   const startAmount = startVtxos.reduce((total, vtxo) => total + vtxo.amount, 0);
-  const walletReady = isWalletLoaded && !isWalletSuspended && !isBackgroundJobRunning;
   const revision = `${overviewQuery.dataUpdatedAt}:${balanceQuery.dataUpdatedAt}:${walletReady}`;
   const startQuote = useExitFeeEstimate(
     {

--- a/client/tests/integration/exitOverview.test.js
+++ b/client/tests/integration/exitOverview.test.js
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import * as ReactQuery from "@tanstack/react-query";
+import { ok } from "neverthrow";
+
+const { QueryClient, QueryObserver } = ReactQuery;
+
+const readyWallet = {
+  isInitialized: true,
+  isWalletLoaded: true,
+  isWalletSuspended: false,
+  isBackgroundJobRunning: false,
+  staticVtxoPubkey: "wallet-a",
+};
+let wallet = { ...readyWallet };
+const nativeReads = [];
+const read = (name, value) => async () => {
+  nativeReads.push(name);
+  return ok(value);
+};
+const useWalletStore = () => wallet;
+useWalletStore.getState = () => wallet;
+
+// Capture the actual hook options; exercise their lifecycle with a real QueryObserver.
+mock.module("@tanstack/react-query", () => ({ ...ReactQuery, useQuery: (options) => options }));
+mock.module("react-native", () => ({ AppState: {} }));
+mock.module("@react-navigation/native", () => ({ useIsFocused: () => true }));
+mock.module("../../src/store/walletStore", () => ({ useWalletStore }));
+mock.module("../../src/contexts/AlertProvider", () => ({ useAlert: () => ({}) }));
+mock.module("../../src/hooks/useMarketData", () => ({ getBlockHeight: async () => ok(100) }));
+mock.module("../../src/lib/log", () => ({ default: () => ({ d() {} }) }));
+mock.module("../../src/lib/walletApi", () => ({ getVtxos: read("getVtxos", []) }));
+const unexpectedAction = () => {
+  throw new Error("Reading the overview must not execute exit actions");
+};
+mock.module("../../src/lib/exitApi", () => ({
+  cancelExit: unexpectedAction,
+  claimExits: unexpectedAction,
+  estimateEmergencyExitFee: unexpectedAction,
+  progressExits: unexpectedAction,
+  startExitForVtxos: unexpectedAction,
+  syncExit: unexpectedAction,
+  getExitVtxos: read("getExitVtxos", [{ vtxo_id: "exit-a" }]),
+  getExitStatus: read("getExitStatus", { state: "Processing" }),
+  listClaimable: read("listClaimable", []),
+  hasPendingExits: read("hasPendingExits", true),
+  pendingExitTotal: read("pendingExitTotal", 1000),
+  allClaimableAtHeight: read("allClaimableAtHeight", 110),
+}));
+const { useExitOverview } = await import("../../src/hooks/useUnilateralExit");
+
+let client;
+function queryOptions() {
+  return useExitOverview();
+}
+
+afterEach(() => {
+  client?.clear();
+  nativeReads.length = 0;
+  wallet = { ...readyWallet };
+});
+
+describe("exit overview wallet coordination", () => {
+  test("does not read on mount or invalidation during a background job, then resumes", async () => {
+    client = new QueryClient();
+    wallet.isBackgroundJobRunning = true;
+    const observer = new QueryObserver(client, queryOptions());
+    const unsubscribe = observer.subscribe(() => {});
+    await client.invalidateQueries({ queryKey: ["exit-overview"] });
+    expect(nativeReads).toEqual([]);
+
+    wallet.isBackgroundJobRunning = false;
+    observer.setOptions(queryOptions());
+    expect(nativeReads).toContain("getExitVtxos");
+    const result = await observer.refetch();
+    expect(result.error).toBeNull();
+    expect(result.data.spendableVtxos).toEqual([]);
+    expect(nativeReads).toContain("getExitVtxos");
+    expect(nativeReads).toContain("getExitStatus");
+    expect(nativeReads).toContain("getVtxos");
+    unsubscribe();
+  });
+
+  test("blocks explicit refetch through a stale observer when the wallet becomes unavailable", async () => {
+    for (const unavailable of [
+      { isBackgroundJobRunning: true },
+      { isWalletSuspended: true },
+      { isWalletLoaded: false },
+      { isInitialized: false },
+    ]) {
+      client = new QueryClient();
+      wallet = { ...readyWallet };
+      const observer = new QueryObserver(client, queryOptions());
+      wallet = { ...readyWallet, ...unavailable };
+      const result = await observer.refetch();
+      expect(nativeReads).toEqual([]);
+      expect(result.isError).toBe(true);
+      client.clear();
+    }
+  });
+});

--- a/client/tests/unit/exitFeeEstimate.test.js
+++ b/client/tests/unit/exitFeeEstimate.test.js
@@ -1,0 +1,159 @@
+import { describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import {
+  EXIT_ESTIMATE_MAX_AGE_MS,
+  exitEstimateKey,
+  exitFeeWarning,
+  exitReceiveAmount,
+  isExitReviewCurrent,
+} from "../../src/lib/exitFeeEstimate";
+
+const estimate = {
+  exit_broadcast_fee_sat: 12_000,
+  claim_fee_sat: 800,
+  total_fee_sat: 12_800,
+  fee_rate_sat_per_vb: 5,
+  txs_to_broadcast: 2,
+  fundable: false,
+};
+const inputs = {
+  walletId: "wallet-a",
+  vtxoIds: ["a", "b"],
+  amountSat: 100_000,
+  scope: "wallet",
+  revision: "1",
+};
+
+describe("emergency exit fee accounting", () => {
+  test("deducts only the claim fee, regardless of broadcast funding", () => {
+    expect(exitReceiveAmount(100_000, estimate.claim_fee_sat)).toBe(99_200);
+    expect(exitFeeWarning(100_000, estimate)).toBeUndefined();
+  });
+
+  test("never displays negative proceeds when claim fees consume the value", () => {
+    expect(exitReceiveAmount(800, 800)).toBe(0);
+    expect(exitReceiveAmount(500, 800)).toBe(0);
+    expect(exitFeeWarning(800, estimate, true)).toContain("entire recovered value");
+  });
+
+  test("warns about total costs at start without counting old broadcast fees at claim", () => {
+    expect(exitFeeWarning(12_800, estimate)).toContain("meet or exceed");
+    expect(exitFeeWarning(12_800, estimate, true)).toBeUndefined();
+    expect(exitReceiveAmount(12_800, estimate.claim_fee_sat)).toBe(12_000);
+  });
+});
+
+describe("exit review correspondence", () => {
+  const review = {
+    inputs,
+    contextKey: exitEstimateKey(inputs),
+    estimate,
+    reviewedAt: 1000,
+  };
+
+  test("treats reordered VTXOs as the same set without mutating inputs", () => {
+    const reordered = { ...inputs, vtxoIds: ["b", "a"] };
+    expect(exitEstimateKey(reordered)).toBe(review.contextKey);
+    expect(reordered.vtxoIds).toEqual(["b", "a"]);
+  });
+
+  test("rejects changed selection, scope, amount, wallet, destination, or wallet state", () => {
+    for (const changed of [
+      { vtxoIds: ["a"] },
+      { vtxoIds: ["a", "b", "new-wallet-funds"] },
+      { scope: "selected" },
+      { amountSat: 200_000 },
+      { walletId: "wallet-b" },
+      { destinationAddress: "destination-b" },
+      { revision: "2" },
+    ]) {
+      expect(isExitReviewCurrent(review, exitEstimateKey({ ...inputs, ...changed }), 1001)).toBe(
+        false,
+      );
+    }
+  });
+
+  test("expires confirmations and applies the same input guard to the emergency fallback", () => {
+    expect(isExitReviewCurrent(review, review.contextKey, 1001)).toBe(true);
+    expect(isExitReviewCurrent(review, review.contextKey, 1000 + EXIT_ESTIMATE_MAX_AGE_MS)).toBe(
+      false,
+    );
+    const fallback = { ...review, estimate: undefined };
+    expect(isExitReviewCurrent(fallback, review.contextKey, 1001)).toBe(true);
+    expect(isExitReviewCurrent(fallback, exitEstimateKey({ ...inputs, vtxoIds: [] }), 1001)).toBe(
+      false,
+    );
+  });
+
+  test("isolates late estimates after rapid selection and destination changes", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    let resolveOld;
+    const oldResult = new Promise((resolve) => {
+      resolveOld = resolve;
+    });
+    const options = (context, queryFn) => ({
+      queryKey: ["exit-fee-estimate", exitEstimateKey(context)],
+      queryFn,
+    });
+    const observer = new QueryObserver(
+      client,
+      options(inputs, () => oldResult),
+    );
+    const unsubscribe = observer.subscribe(() => {});
+    const oldFetch = client.fetchQuery(options(inputs, () => oldResult));
+    const changed = {
+      ...inputs,
+      vtxoIds: ["b"],
+      scope: "claim",
+      destinationAddress: "destination-b",
+    };
+    const nextEstimate = { ...estimate, claim_fee_sat: 400 };
+    observer.setOptions(options(changed, async () => nextEstimate));
+    expect(observer.getCurrentResult().data).toBeUndefined();
+    await client.fetchQuery(options(changed, async () => nextEstimate));
+    resolveOld(estimate);
+    await oldFetch;
+    expect(observer.getCurrentResult().data).toEqual(nextEstimate);
+    expect(isExitReviewCurrent(review, exitEstimateKey(changed), 1001)).toBe(false);
+    unsubscribe();
+    client.clear();
+  });
+});
+
+const nativeEstimate = mock(async () => estimate);
+const nativeSync = mock(async () => {});
+const nativeProgress = mock(async () => []);
+mock.module("react-native-nitro-ark", () => ({
+  estimateEmergencyExitFee: nativeEstimate,
+  syncExit: nativeSync,
+  progressExits: nativeProgress,
+}));
+mock.module("../../src/lib/log", () => ({
+  default: () => ({ d: () => {}, i: () => {}, w: () => {}, e: () => {} }),
+}));
+const { estimateEmergencyExitFee } = await import("../../src/lib/exitApi");
+
+describe("read-only exit estimator boundary", () => {
+  test("quotes the full set together with automatic rates and the exact claim destination", async () => {
+    const result = await estimateEmergencyExitFee(["a", "b"], "claim-destination");
+    expect(result.isOk()).toBe(true);
+    expect(result.value).toEqual(estimate);
+    expect(nativeEstimate).toHaveBeenLastCalledWith(["a", "b"], undefined, "claim-destination");
+    expect(nativeSync).not.toHaveBeenCalled();
+    expect(nativeProgress).not.toHaveBeenCalled();
+  });
+
+  test("does not require a destination for a new exit", async () => {
+    await estimateEmergencyExitFee(["a", "b"]);
+    expect(nativeEstimate).toHaveBeenLastCalledWith(["a", "b"], undefined, undefined);
+  });
+
+  test("returns recoverable estimator failures without progressing exits", async () => {
+    nativeEstimate.mockRejectedValueOnce(new Error("Estimator unavailable"));
+    const result = await estimateEmergencyExitFee(["a"]);
+    expect(result.isErr()).toBe(true);
+    expect(result.error.message).toBe("Estimator unavailable");
+    expect(nativeSync).not.toHaveBeenCalled();
+    expect(nativeProgress).not.toHaveBeenCalled();
+  });
+});

--- a/client/tests/unit/exitOverviewCoordination.test.js
+++ b/client/tests/unit/exitOverviewCoordination.test.js
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+
+// Keep native module mocks isolated from the other wallet unit tests.
+test("exit overview queries respect wallet availability", async () => {
+  const proc = Bun.spawn([process.execPath, "test", "tests/integration/exitOverview.test.js"], {
+    cwd: new URL("../../", import.meta.url).pathname,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  expect(exitCode, `${stdout}\n${stderr}`).toBe(0);
+});


### PR DESCRIPTION
Emergency Exit now previews broadcast fees, claim fees, and the amount users can recover before starting or claiming an exit. Broadcast fees are funded separately by confirmed onchain funds; only the claim fee is deducted from recovered value. Estimates refresh for the selected VTXOs and claim destination, and confirmations reject expired estimates or changed wallet inputs. An explicit fallback remains available when estimation fails.

When broadcast funding is insufficient, **Deposit Onchain Funds** opens a bottom sheet with a Bitcoin address, QR code, the existing Receive clipboard icon, and a suggested deposit based on broadcast fees. The suggestion is an estimate, not an exact funding shortfall. Users remain on Emergency Exit. Status refresh reads saved state; chain checks and broadcasts require the explicit Progress action.

Also fixes the Send recipient Continue button being clipped when the iOS keyboard opens: the fixed-height native button no longer applies a second keyboard safe-area adjustment.

Validation:
- `nix develop --command just check`: lint, all 96 unit tests, and TypeScript pass. New coverage exercises fee accounting, stale review rejection, late estimate isolation, and the read-only estimator boundary.
- iOS regtest simulator: reviewed entire-wallet and selected-VTXO estimates and confirmations; verified deposit sheet dismissal and clipboard behavior. Decoded the displayed QR and confirmed it matches the copied address.
- Reproduced the clipped button at 28 points of visible height; verified its full 56-point height after opening and closing the keyboard with the fix.
- No exit or claim transactions were submitted during validation.
